### PR TITLE
Harden camera preview window

### DIFF
--- a/src/main/handlers/camera-handlers.ts
+++ b/src/main/handlers/camera-handlers.ts
@@ -162,10 +162,10 @@ async function createPreviewWindow(
     transparent: true,
     title: deviceName,
     webPreferences: {
-      nodeIntegration: true,
-      contextIsolation: false,
-      preload: path.join(__dirname, '../preload/index.js'),
-      webSecurity: false,
+      nodeIntegration: false,
+      contextIsolation: true,
+      preload: path.join(__dirname, '../preload/cameraPreview.js'),
+      webSecurity: true,
       additionalArguments: [`--camera-device-id=${deviceId}`, `--camera-device-name=${deviceName}`]
     }
   })

--- a/src/preload/cameraPreview.ts
+++ b/src/preload/cameraPreview.ts
@@ -1,0 +1,14 @@
+import { contextBridge, ipcRenderer } from 'electron'
+
+export const cameraPreview = {
+  closeWindow: (deviceId: string) =>
+    ipcRenderer.invoke('camera:close-preview-window', deviceId),
+  hidePreview: () => ipcRenderer.invoke('camera:hide-preview-window')
+}
+
+if (process.contextIsolated) {
+  contextBridge.exposeInMainWorld('cameraPreview', cameraPreview)
+} else {
+  // @ts-ignore
+  window.cameraPreview = cameraPreview
+}

--- a/src/renderer/camera-preview.html
+++ b/src/renderer/camera-preview.html
@@ -251,11 +251,8 @@
             const deviceId = urlParams.get('deviceId') || 'default'
 
             try {
-              // 直接ipcRendererを使用してIPCハンドラーと通信
-              const { ipcRenderer } = require('electron')
-
               console.log('Attempting to close individual preview window:', deviceId)
-              const result = await ipcRenderer.invoke('camera:close-preview-window', deviceId)
+              const result = await window.cameraPreview.closeWindow(deviceId)
 
               if (result.success) {
                 console.log('Individual window close result:', result.message)
@@ -486,8 +483,7 @@
         async fallbackClose() {
           try {
             console.log('Attempting fallback close using hidePreviewWindow')
-            const { ipcRenderer } = require('electron')
-            const result = await ipcRenderer.invoke('camera:hide-preview-window')
+            const result = await window.cameraPreview.hidePreview()
 
             if (result.success) {
               console.log('Fallback close successful:', result.message)

--- a/src/types/electron.ts
+++ b/src/types/electron.ts
@@ -23,5 +23,9 @@ declare global {
       log: RendererLogger
       createCategoryLogger: (category: string) => RendererCategoryLogger
     }
+    cameraPreview: {
+      closeWindow: (deviceId: string) => Promise<any>
+      hidePreview: () => Promise<any>
+    }
   }
 }


### PR DESCRIPTION
## Summary
- secure preview window by disabling Node integration
- add dedicated preload script for camera preview windows
- use the preload API instead of requiring Electron
- extend type definitions for the new API

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68882102d0c88331a573d33cd8720bb6