### PR TITLE
Add strict CSP to renderer HTML

### DIFF
--- a/src/renderer/camera-preview.html
+++ b/src/renderer/camera-preview.html
@@ -4,6 +4,10 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Camera Preview</title>
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; script-src 'self' 'sha256-M5Ugm22BeXjC//wgZr5kxKUSHClb4p34C6CIe3jKQVw='; style-src 'self' 'unsafe-inline'; img-src 'self' data:"
+    />
     <style>
       * {
         margin: 0;

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -4,10 +4,10 @@
     <meta charset="UTF-8" />
     <title>Bedrock Engineer</title>
     <!-- https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP -->
-    <!-- <meta
+    <meta
       http-equiv="Content-Security-Policy"
       content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:"
-    /> -->
+    />
   </head>
 
   <body>


### PR DESCRIPTION
## Summary
- enable strict CSP in `index.html` and `camera-preview.html`
- hash inline script in camera preview

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688822bcdbac8331b67a853039bdb4b4