### PR TITLE
Sanitize Mermaid charts and enforce strict security

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "chart.js": "^4.4.8",
         "cors": "2.8.5",
         "diff": "6.0.0",
+        "dompurify": "^3.2.6",
         "electron-store": "8.2.0",
         "electron-updater": "^6.3.9",
         "express": "^4.21.2",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "chart.js": "^4.4.8",
     "cors": "2.8.5",
     "diff": "6.0.0",
+    "dompurify": "^3.2.6",
     "electron-store": "8.2.0",
     "electron-updater": "^6.3.9",
     "express": "^4.21.2",


### PR DESCRIPTION
## Summary
- add DOMPurify dependency
- render Mermaid diagrams in strict security mode
- sanitize chart input and SVG output when rendering

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688822bd3b588331afd5b99cb5b2ab20