### PR TITLE
Fix build by adding missing Tailwind type

### DIFF
--- a/src/types/tailwindcss.d.ts
+++ b/src/types/tailwindcss.d.ts
@@ -1,0 +1,1 @@
+declare module 'tailwindcss';


### PR DESCRIPTION
## Summary
- add `tailwindcss` module declaration so TypeScript can resolve the plugin import

## Testing
- `npx tsc --noEmit -p tsconfig.node.json` *(fails: missing SDK modules)*

------
https://chatgpt.com/codex/tasks/task_e_68880861421c833190f70fe1a7529dcd