### PR TITLE
Refactor session file reads to be async

### DIFF
--- a/src/main/handlers/todo-handlers.ts
+++ b/src/main/handlers/todo-handlers.ts
@@ -104,7 +104,7 @@ export const todoHandlers = {
       }
 
       const manager = getTodoSessionManager()
-      const todoList = manager.getTodoList(params.sessionId)
+      const todoList = await manager.getTodoList(params.sessionId)
 
       log.debug('Retrieved TODO list from store', {
         todoList: todoList ? { id: todoList.id, itemCount: todoList.items.length } : null,

--- a/src/main/store/chatSession.ts
+++ b/src/main/store/chatSession.ts
@@ -32,10 +32,10 @@ export class ChatSessionManager {
     })
 
     // 初回起動時またはメタデータが空の場合、既存のセッションからメタデータを生成
-    this.initializeMetadata()
+    void this.initializeMetadata()
   }
 
-  private initializeMetadata(): void {
+  private async initializeMetadata(): Promise<void> {
     const metadata = this.metadataStore.get('metadata')
     if (Object.keys(metadata).length === 0) {
       try {
@@ -44,7 +44,7 @@ export class ChatSessionManager {
 
         for (const file of sessionFiles) {
           const sessionId = file.replace('.json', '')
-          const session = this.readSessionFile(sessionId)
+          const session = await this.readSessionFile(sessionId)
           if (session) {
             this.updateMetadata(sessionId, session)
           }
@@ -61,10 +61,10 @@ export class ChatSessionManager {
     return path.join(this.sessionsDir, `${sessionId}.json`)
   }
 
-  private readSessionFile(sessionId: string): ChatSession | null {
+  private async readSessionFile(sessionId: string): Promise<ChatSession | null> {
     const filePath = this.getSessionFilePath(sessionId)
     try {
-      const data = fs.readFileSync(filePath, 'utf-8')
+      const data = await fs.promises.readFile(filePath, 'utf-8')
       return JSON.parse(data) as ChatSession
     } catch (error) {
       console.error(`Error reading session file ${sessionId}:`, error)
@@ -120,7 +120,7 @@ export class ChatSessionManager {
   }
 
   async addMessage(sessionId: string, message: ChatMessage): Promise<void> {
-    const session = this.readSessionFile(sessionId)
+    const session = await this.readSessionFile(sessionId)
     if (!session) return
 
     session.messages.push(message)
@@ -131,12 +131,12 @@ export class ChatSessionManager {
     this.updateRecentSessions(sessionId)
   }
 
-  getSession(sessionId: string): ChatSession | null {
-    return this.readSessionFile(sessionId)
+  async getSession(sessionId: string): Promise<ChatSession | null> {
+    return await this.readSessionFile(sessionId)
   }
 
   async updateSessionTitle(sessionId: string, title: string): Promise<void> {
-    const session = this.readSessionFile(sessionId)
+    const session = await this.readSessionFile(sessionId)
     if (!session) return
 
     session.title = title
@@ -232,7 +232,7 @@ export class ChatSessionManager {
     messageIndex: number,
     updatedMessage: ChatMessage
   ): Promise<void> {
-    const session = this.readSessionFile(sessionId)
+    const session = await this.readSessionFile(sessionId)
     if (!session) return
 
     // 指定されたインデックスが有効な範囲内かチェック
@@ -251,7 +251,7 @@ export class ChatSessionManager {
   }
 
   async deleteMessage(sessionId: string, messageIndex: number): Promise<void> {
-    const session = this.readSessionFile(sessionId)
+    const session = await this.readSessionFile(sessionId)
     if (!session) return
 
     // 指定されたインデックスが有効な範囲内かチェック

--- a/src/main/store/todoSession.ts
+++ b/src/main/store/todoSession.ts
@@ -70,10 +70,10 @@ export class TodoSessionManager {
     })
 
     // 初回起動時またはメタデータが空の場合、既存のTODOリストからメタデータを生成
-    this.initializeMetadata()
+    void this.initializeMetadata()
   }
 
-  private initializeMetadata(): void {
+  private async initializeMetadata(): Promise<void> {
     const metadata = this.metadataStore.get('metadata')
     if (Object.keys(metadata).length === 0) {
       try {
@@ -82,7 +82,7 @@ export class TodoSessionManager {
 
         for (const file of todoFiles) {
           const fileId = file.replace('_todos.json', '')
-          const todoList = this.readTodoFile(fileId)
+          const todoList = await this.readTodoFile(fileId)
           if (todoList) {
             this.updateMetadata(fileId, todoList)
           }
@@ -103,10 +103,10 @@ export class TodoSessionManager {
     return path.join(this.todosDir, fileName)
   }
 
-  private readTodoFile(sessionId: string): TodoList | null {
+  private async readTodoFile(sessionId: string): Promise<TodoList | null> {
     const filePath = this.getTodoFilePath(sessionId)
     try {
-      const data = fs.readFileSync(filePath, 'utf-8')
+      const data = await fs.promises.readFile(filePath, 'utf-8')
       return JSON.parse(data) as TodoList
     } catch (error) {
       console.error(`Error reading todo file ${sessionId}:`, error)
@@ -168,7 +168,7 @@ export class TodoSessionManager {
 
   async updateTodoList(sessionId: string, updates: TodoItemUpdate[]): Promise<TodoUpdateResult> {
     try {
-      const todoList = this.readTodoFile(sessionId)
+      const todoList = await this.readTodoFile(sessionId)
       if (!todoList) {
         return {
           success: false,
@@ -220,8 +220,8 @@ export class TodoSessionManager {
     }
   }
 
-  getTodoList(sessionId: string): TodoList | null {
-    return this.readTodoFile(sessionId)
+  async getTodoList(sessionId: string): Promise<TodoList | null> {
+    return await this.readTodoFile(sessionId)
   }
 
   deleteTodoList(sessionId: string): void {

--- a/src/preload/chat-history.ts
+++ b/src/preload/chat-history.ts
@@ -13,8 +13,8 @@ export const chatHistory = {
     return await chatSessionManager.addMessage(sessionId, message)
   },
 
-  getSession(sessionId: string) {
-    return chatSessionManager.getSession(sessionId)
+  async getSession(sessionId: string) {
+    return await chatSessionManager.getSession(sessionId)
   },
 
   async updateSessionTitle(sessionId: string, title: string) {

--- a/src/renderer/src/contexts/ChatHistoryContext.tsx
+++ b/src/renderer/src/contexts/ChatHistoryContext.tsx
@@ -4,7 +4,7 @@ import { SessionMetadata, ChatSession, ChatMessage } from '@/types/chat/history'
 interface ChatHistoryContextType {
   sessions: SessionMetadata[]
   currentSessionId?: string
-  getSession: (sessionId: string) => ChatSession | null
+  getSession: (sessionId: string) => Promise<ChatSession | null>
   createSession: (agentId: string, modelId: string, systemPrompt?: string) => Promise<string>
   addMessage: (sessionId: string, message: ChatMessage) => Promise<void>
   updateSessionTitle: (sessionId: string, title: string) => Promise<void>
@@ -43,8 +43,8 @@ export const ChatHistoryProvider: React.FC<{ children: React.ReactNode }> = ({ c
   }, [])
 
   // セッション情報を取得
-  const getSession = useCallback((sessionId: string) => {
-    return window.chatHistory.getSession(sessionId)
+  const getSession = useCallback(async (sessionId: string) => {
+    return await window.chatHistory.getSession(sessionId)
   }, [])
 
   // 新規セッションを作成

--- a/src/renderer/src/pages/ChatPage/components/ChatHistory/index.tsx
+++ b/src/renderer/src/pages/ChatPage/components/ChatHistory/index.tsx
@@ -83,7 +83,7 @@ export const ChatHistory: React.FC<ChatHistoryProps> = ({ onSessionSelect, curre
 
     try {
       // セッションの詳細を取得
-      const sessionDetails = getSession(session.id)
+      const sessionDetails = await getSession(session.id)
       if (!sessionDetails) {
         throw new Error('Session not found')
       }

--- a/src/renderer/src/pages/ChatPage/hooks/useAgentChat.ts
+++ b/src/renderer/src/pages/ChatPage/hooks/useAgentChat.ts
@@ -255,7 +255,7 @@ export const useAgentChat = (
   useEffect(() => {
     const initSession = async () => {
       if (sessionId) {
-        const session = getSession(sessionId)
+        const session = await getSession(sessionId)
         if (session) {
           // 既存の通信があれば中断
           abortCurrentRequest()
@@ -285,17 +285,21 @@ export const useAgentChat = (
 
   // currentSessionId が変わった時の処理
   useEffect(() => {
-    if (currentSessionId) {
-      // セッション切り替え時に進行中の通信を中断
-      abortCurrentRequest()
-      const session = getSession(currentSessionId)
-      if (session) {
-        setMessages(session.messages as Message[])
-        setActiveSession(currentSessionId)
-        // セッション切り替え時にキャッシュポイントをリセット
-        lastCachePoint.current = undefined
+    const fetchSession = async () => {
+      if (currentSessionId) {
+        // セッション切り替え時に進行中の通信を中断
+        abortCurrentRequest()
+        const session = await getSession(currentSessionId)
+        if (session) {
+          setMessages(session.messages as Message[])
+          setActiveSession(currentSessionId)
+          // セッション切り替え時にキャッシュポイントをリセット
+          lastCachePoint.current = undefined
+        }
       }
     }
+
+    fetchSession()
   }, [currentSessionId, getSession, setActiveSession, abortCurrentRequest])
 
   // メッセージの永続化を行うラッパー関数
@@ -1045,7 +1049,7 @@ export const useAgentChat = (
 
     try {
       // セッションの詳細を取得
-      const session = getSession(currentSessionId)
+      const session = await getSession(currentSessionId)
       if (!session) return
 
       // セッションのタイトルが既にカスタマイズされている場合は生成しない


### PR DESCRIPTION
## Summary
- refactor `ChatSessionManager` and `TodoSessionManager` to use async file reads
- update preload and renderer usage to await async functions
- fix todo handler to await new `getTodoList`

## Testing
- `npm test`
- `npm run typecheck`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688822be17c48331844c098fb9fe6fd0