### PR TITLE
Fix camera preview security settings

### DIFF
--- a/src/main/handlers/camera-handlers.ts
+++ b/src/main/handlers/camera-handlers.ts
@@ -162,10 +162,10 @@ async function createPreviewWindow(
     transparent: true,
     title: deviceName,
     webPreferences: {
-      nodeIntegration: true,
-      contextIsolation: false,
+      nodeIntegration: false,
+      contextIsolation: true,
       preload: path.join(__dirname, '../preload/index.js'),
-      webSecurity: false,
+      webSecurity: true,
       additionalArguments: [`--camera-device-id=${deviceId}`, `--camera-device-name=${deviceName}`]
     }
   })

--- a/src/renderer/camera-preview.html
+++ b/src/renderer/camera-preview.html
@@ -251,11 +251,8 @@
             const deviceId = urlParams.get('deviceId') || 'default'
 
             try {
-              // 直接ipcRendererを使用してIPCハンドラーと通信
-              const { ipcRenderer } = require('electron')
-
               console.log('Attempting to close individual preview window:', deviceId)
-              const result = await ipcRenderer.invoke('camera:close-preview-window', deviceId)
+              const result = await window.api.camera.closePreviewWindow(deviceId)
 
               if (result.success) {
                 console.log('Individual window close result:', result.message)
@@ -486,8 +483,7 @@
         async fallbackClose() {
           try {
             console.log('Attempting fallback close using hidePreviewWindow')
-            const { ipcRenderer } = require('electron')
-            const result = await ipcRenderer.invoke('camera:hide-preview-window')
+            const result = await window.api.camera.hidePreviewWindow()
 
             if (result.success) {
               console.log('Fallback close successful:', result.message)


### PR DESCRIPTION
## Summary
- disable `nodeIntegration` and enable `contextIsolation` and `webSecurity` for camera preview windows
- use `window.api.camera` methods instead of `ipcRenderer` in `camera-preview.html`

## Testing
- `ESLINT_USE_FLAT_CONFIG=false npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688846bf93c08331b3a71ea1c2474226