### PR TITLE
Use get-port for available port selection

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,14 +1,18 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} **/
+const esModules = ['get-port']
+
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
+  transformIgnorePatterns: [`/node_modules/(?!${esModules.join('|')})`],
   transform: {
     '^.+.tsx?$': [
       'ts-jest',
       {
         tsconfig: 'tsconfig.test.json'
       }
-    ]
+    ],
+    '^.+\\.[jt]sx?$': 'babel-jest'
   },
   testMatch: ['**/*.test.ts'],
   testPathIgnorePatterns: [

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "fix-path": "^4.0.0",
     "flowbite-react": "0.10.1",
     "framer-motion": "11.3.29",
+    "get-port": "^7.1.0",
     "https-proxy-agent": "^7.0.6",
     "i18next": "23.15.0",
     "lodash": "^4.17.21",

--- a/src/preload/lib/random-port.ts
+++ b/src/preload/lib/random-port.ts
@@ -1,35 +1,10 @@
-const net = require('net')
+const MAX_PORT = 65535
+const MIN_PORT = 3500 // avoid wellknown port
 
-const MAXPORT = 65536
-const MINPORT = 3500 // avoid wellknown port
-
-const getRandomPort = (beginPort?: number): Promise<number> => {
-  const r = Math.random() * (MAXPORT - MINPORT) + MINPORT
-  let PORT = beginPort || Math.floor(r)
-  return new Promise((resolve, reject) => {
-    const nextPort = () => {
-      const port = PORT++
-      if (port <= 1) {
-        return reject(new Error('Under min port number'))
-      }
-      if (port > 65536) {
-        return reject(new Error('Over max port number'))
-      }
-      const server = net.createServer()
-      server.on('error', () => {
-        console.log('port ' + port + ' is occupied')
-        nextPort()
-      })
-      server.listen(port, () => {
-        server.once('close', () => {
-          resolve(port)
-        })
-        server.close()
-      })
-    }
-
-    nextPort()
-  })
+const getRandomPort = async (beginPort?: number): Promise<number> => {
+  const { default: getPort, portNumbers } = await import('get-port')
+  const start = beginPort ?? MIN_PORT
+  return getPort({ port: portNumbers(start, MAX_PORT) })
 }
 
 export default getRandomPort


### PR DESCRIPTION
## Summary
- replace custom random-port logic with `get-port`
- add `get-port` package
- configure Jest to transform `get-port`

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68884c37d0648331915d8a114e07059c