### PR TITLE
Add Windows path support for MCP commands

### DIFF
--- a/src/preload/mcp/command-resolver.ts
+++ b/src/preload/mcp/command-resolver.ts
@@ -2,57 +2,95 @@ import fs from 'fs'
 import path from 'path'
 import os from 'os'
 import { execSync } from 'child_process'
+import { store } from '../store'
 
 /**
  * コマンド実行可能ファイルのパスを解決する
- * TODO: Windowsへの対応と動作確認が必要
- * TODO: PATH の設定をユーザー側で制御可能にする
+ * Windowsのパス検索やユーザー設定から追加されたPATHに対応
  * @param command コマンド名（uvx など）
  * @returns 解決されたコマンドパス
  */
 export function resolveCommand(command: string): string {
   try {
-    // 1. 絶対パスの場合はそのまま使用
+    const isWindows = process.platform === 'win32'
+
+    // 設定で追加されたPATHを取得
+    const additionalPaths =
+      (store.get('commandSearchPaths') as string[] | undefined) || []
+
+    // 1. 絶対パスの場合はそのまま使用 (Windowsでは拡張子も考慮)
     if (path.isAbsolute(command)) {
       if (fs.existsSync(command)) {
         return command
       }
+      if (isWindows) {
+        const resolved = tryExtensions(command)
+        if (resolved) {
+          return resolved
+        }
+      }
     }
 
     // 2. 一般的なインストール先を確認
-    const commonPaths = [
-      // グローバルnpmパッケージのパス
-      '/usr/local/bin',
-      '/opt/homebrew/bin',
-      // Apple Silicon Mac用のHomebrew
-      '/opt/homebrew/bin',
-      // Intel Mac用のHomebrew
-      '/usr/local/bin',
-      // ユーザーのホームディレクトリ内のbin
-      path.join(os.homedir(), '.npm-global/bin'),
-      path.join(os.homedir(), 'bin'),
-      path.join(os.homedir(), '.local/bin')
-    ]
+    const commonPaths = isWindows
+      ? [
+          'C:/Program Files/nodejs',
+          'C:/Program Files/Git/cmd',
+          'C:/Program Files/Amazon/AWSCLIV2',
+          path.join(os.homedir(), 'AppData/Local/Microsoft/WindowsApps')
+        ]
+      : [
+          '/usr/local/bin',
+          '/opt/homebrew/bin',
+          // Apple Silicon Mac用のHomebrew
+          '/opt/homebrew/bin',
+          // Intel Mac用のHomebrew
+          '/usr/local/bin',
+          // ユーザーのホームディレクトリ内のbin
+          path.join(os.homedir(), '.npm-global/bin'),
+          path.join(os.homedir(), 'bin'),
+          path.join(os.homedir(), '.local/bin')
+        ]
 
-    for (const dir of commonPaths) {
+    const envPaths = process.env.PATH ? process.env.PATH.split(path.delimiter) : []
+    const searchPaths = [...additionalPaths, ...commonPaths, ...envPaths]
+
+    for (const dir of searchPaths) {
       try {
         const fullPath = path.join(dir, command)
         if (fs.existsSync(fullPath)) {
           return fullPath
         }
-      } catch (err) {
+        if (isWindows) {
+          const winPath = tryExtensions(fullPath)
+          if (winPath) {
+            return winPath
+          }
+        }
+      } catch {
         // エラーを無視して次のパスを試行
       }
     }
 
-    // 3. macOS/Linux環境ではwhichコマンドで探索
-    if (process.platform !== 'win32') {
+    // 3. OS固有の探索コマンドで検索
+    if (isWindows) {
+      try {
+        const wherePath = execSync(`where ${command}`, { encoding: 'utf8' })
+          .split('\n')[0]
+          .trim()
+        if (wherePath && fs.existsSync(wherePath)) {
+          return wherePath
+        }
+      } catch {
+        // whereコマンドが失敗した場合は無視
+      }
+    } else {
       try {
         const whichPath = execSync(`which ${command}`, { encoding: 'utf8' }).trim()
         if (whichPath && fs.existsSync(whichPath)) {
           return whichPath
         }
-      } catch (err) {
+      } catch {
         // whichコマンドが失敗した場合は無視
       }
     }
@@ -62,4 +100,18 @@ export function resolveCommand(command: string): string {
 
   // 最終的には元のコマンド名を返す
   return command
+}
+
+function tryExtensions(basePath: string): string | undefined {
+  const exts = (process.env.PATHEXT || '.EXE;.CMD;.BAT;.COM')
+    .split(';')
+    .map((e) => e.toLowerCase())
+
+  for (const ext of exts) {
+    const target = basePath.endsWith(ext.toLowerCase()) ? basePath : basePath + ext
+    if (fs.existsSync(target)) {
+      return target
+    }
+  }
+  return undefined
 }

--- a/src/preload/store.ts
+++ b/src/preload/store.ts
@@ -131,6 +131,9 @@ type StoreScheme = {
   /** コマンド実行の設定（シェル設定） */
   shell: string
 
+  /** 追加のPATH設定 */
+  commandSearchPaths?: string[]
+
   /** 通知機能の有効/無効設定 */
   notification?: boolean
 
@@ -250,6 +253,10 @@ const init = () => {
   const shell = electronStore.get('shell')
   if (!shell) {
     electronStore.set('shell', DEFAULT_SHELL)
+  }
+  const commandSearchPaths = electronStore.get('commandSearchPaths')
+  if (!commandSearchPaths) {
+    electronStore.set('commandSearchPaths', [])
   }
 
   // Initialize bedrockSettings

--- a/src/renderer/src/contexts/SettingsContext.tsx
+++ b/src/renderer/src/contexts/SettingsContext.tsx
@@ -238,6 +238,8 @@ export interface SettingsContextType {
   // Shell Settings
   shell: string
   setShell: (shell: string) => void
+  commandSearchPaths: string[]
+  setCommandSearchPaths: (paths: string[]) => void
 
   // Ignore Files Settings
   ignoreFiles: string[]
@@ -400,6 +402,7 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
 
   // Shell Settings
   const [shell, setStateShell] = useState<string>('/bin/bash')
+  const [commandSearchPaths, setStateCommandSearchPaths] = useState<string[]>([])
 
   // Ignore Files Settings
   const [ignoreFiles, setStateIgnoreFiles] = useState<string[]>([
@@ -633,6 +636,10 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
     const shell = window.store.get('shell')
     if (shell) {
       setStateShell(shell)
+    }
+    const savedPaths = window.store.get('commandSearchPaths')
+    if (Array.isArray(savedPaths)) {
+      setStateCommandSearchPaths(savedPaths)
     }
 
     // Load Ignore Files Settings および Context Length
@@ -1231,6 +1238,11 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
     window.store.set('shell', newShell)
   }
 
+  const setCommandSearchPaths = useCallback((paths: string[]) => {
+    setStateCommandSearchPaths(paths)
+    window.store.set('commandSearchPaths', paths)
+  }, [])
+
   const setIgnoreFiles = useCallback((files: string[]) => {
     setStateIgnoreFiles(files)
     const agentChatConfig = window.store.get('agentChatConfig') || {}
@@ -1812,6 +1824,8 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
     // Shell Settings
     shell,
     setShell,
+    commandSearchPaths,
+    setCommandSearchPaths,
 
     // Ignore Files Settings
     ignoreFiles,


### PR DESCRIPTION
## Summary
- resolve command paths on Windows and use additional PATH entries
- save custom command search paths in the store
- expose command search path settings via SettingsContext

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6888531ddbc48331bc7f5e560a68d48d