### PR TITLE
Expand notification i18n

### DIFF
--- a/src/main/api/bedrock/services/NotificationService.ts
+++ b/src/main/api/bedrock/services/NotificationService.ts
@@ -2,6 +2,7 @@ import { Notification, BrowserWindow } from 'electron'
 import { createCategoryLogger } from '../../../../common/logger'
 import { ServiceContext } from '../types'
 import { windowHandlers } from '../../../handlers/window-handlers'
+import { t } from '../../i18n'
 
 const logger = createCategoryLogger('notification-service')
 
@@ -83,14 +84,17 @@ export class MainNotificationService {
       let title: string
       let body: string
 
+      const language =
+        (this.context.store.get('language') as 'en' | 'ja') ?? 'en'
+
       if (success) {
         // 成功通知
-        title = 'Background Agent Task Completed' // TODO: i18n対応
-        body = aiMessage || 'Task completed successfully'
+        title = t('notification.backgroundAgent.success.title', language)
+        body = aiMessage || t('notification.backgroundAgent.success.body', language)
       } else {
         // エラー通知
-        title = 'Background Agent Task Failed' // TODO: i18n対応
-        body = error || 'Task execution failed'
+        title = t('notification.backgroundAgent.error.title', language)
+        body = error || t('notification.backgroundAgent.error.body', language)
       }
 
       // 通知設定をstoreから取得

--- a/src/main/i18n/index.ts
+++ b/src/main/i18n/index.ts
@@ -1,0 +1,18 @@
+import en from './locales/en'
+import ja from './locales/ja'
+
+export type Locale = 'en' | 'ja'
+
+const resources = { en, ja }
+
+export function t(key: string, locale: Locale = 'en'): string {
+  const parts = key.split('.')
+  let result: any = resources[locale] as any
+  for (const part of parts) {
+    result = result?.[part]
+    if (result === undefined) {
+      return key
+    }
+  }
+  return typeof result === 'string' ? result : key
+}

--- a/src/main/i18n/locales/en.ts
+++ b/src/main/i18n/locales/en.ts
@@ -1,0 +1,16 @@
+const en = {
+  notification: {
+    backgroundAgent: {
+      success: {
+        title: 'Background Agent Task Completed',
+        body: 'Task completed successfully'
+      },
+      error: {
+        title: 'Background Agent Task Failed',
+        body: 'Task execution failed'
+      }
+    }
+  }
+}
+
+export default en

--- a/src/main/i18n/locales/ja.ts
+++ b/src/main/i18n/locales/ja.ts
@@ -1,0 +1,16 @@
+const ja = {
+  notification: {
+    backgroundAgent: {
+      success: {
+        title: 'バックグラウンドタスク完了',
+        body: 'タスクが正常に完了しました'
+      },
+      error: {
+        title: 'バックグラウンドタスク失敗',
+        body: 'タスクの実行に失敗しました'
+      }
+    }
+  }
+}
+
+export default ja

--- a/src/renderer/src/services/NotificationService.ts
+++ b/src/renderer/src/services/NotificationService.ts
@@ -1,3 +1,5 @@
+import i18n from '@renderer/i18n/config'
+
 export class NotificationService {
   private static instance: NotificationService
 
@@ -54,7 +56,7 @@ export class NotificationService {
 
     try {
       const defaultOptions: NotificationOptions = {
-        body: 'AIからの返信が届きました',
+        body: i18n.t('notification.messages.chatComplete.body'),
         icon: '/icon.png', // アプリケーションのアイコンを使用
         silent: false, // 通知音を有効化
         ...options


### PR DESCRIPTION
## Summary
- localize renderer NotificationService default messages

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6888562c237c83318a6501c2bcbdd137