### PR TITLE
Pin babel-jest to 29.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -90,7 +90,7 @@
         "@types/react-syntax-highlighter": "^15.5.13",
         "@vitejs/plugin-react": "4.3.4",
         "autoprefixer": "10.4.20",
-        "babel-jest": "^30.0.5",
+        "babel-jest": "^29.7.0",
         "dotenv": "^16.4.5",
         "electron": "36.3.2",
         "electron-builder": "24.13.3",
@@ -11510,9 +11510,9 @@
       }
     },
     "node_modules/babel-jest": {
-      "version": "30.0.5",
-      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.0.5.tgz",
-      "integrity": "sha512-mRijnKimhGDMsizTvBTWotwNpzrkHr+VvZUQBof2AufXKB8NXrL1W69TG20EvOz7aevx6FTJIaBuBkYxS8zolg==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
+      "integrity": "sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "@types/react-syntax-highlighter": "^15.5.13",
     "@vitejs/plugin-react": "4.3.4",
     "autoprefixer": "10.4.20",
-    "babel-jest": "^30.0.5",
+    "babel-jest": "^29.7.0",
     "dotenv": "^16.4.5",
     "electron": "36.3.2",
     "electron-builder": "24.13.3",


### PR DESCRIPTION
## Summary
- pin `babel-jest` in `package.json` to the 29.x series
- update `package-lock.json` accordingly

## Testing
- `npm ci --ignore-scripts` *(fails: Missing packages in lock file)*

------
https://chatgpt.com/codex/tasks/task_e_6889931eca388331b3452e83c897d93f