### PR TITLE
Refactor main logs to use unified logger

### DIFF
--- a/src/main/api/bedrock/services/agentService.ts
+++ b/src/main/api/bedrock/services/agentService.ts
@@ -11,6 +11,7 @@ import {
 } from '@aws-sdk/client-bedrock-agent-runtime'
 import { createAgentRuntimeClient } from '../client'
 import type { ServiceContext } from '../types'
+import { log } from '../../../../common/logger'
 
 // 必須パラメータと省略可能パラメータを明確に分離
 type RequiredAgentParams = {
@@ -85,7 +86,7 @@ export class AgentService {
 
     try {
       const response = await agentClient.send(command)
-      console.log({ response })
+      log.debug({ response })
       return {
         $metadata: response.$metadata,
         contentType: response.contentType,
@@ -95,7 +96,7 @@ export class AgentService {
           : undefined
       }
     } catch (error) {
-      console.error('Error invoking agent:', error)
+      log.error('Error invoking agent:', error)
       throw error
     }
   }
@@ -139,7 +140,7 @@ export class AgentService {
         }
       }
     } catch (error) {
-      console.error('Error reading stream:', error)
+      log.error('Error reading stream:', error)
       throw error
     }
     return response

--- a/src/main/api/bedrock/services/flowService.ts
+++ b/src/main/api/bedrock/services/flowService.ts
@@ -10,6 +10,7 @@ import {
 } from '@aws-sdk/client-bedrock-agent-runtime'
 import { createAgentRuntimeClient } from '../client'
 import type { ServiceContext } from '../types'
+import { log } from '../../../../common/logger'
 
 export type InvokeFlowInput = {
   flowIdentifier: string
@@ -78,7 +79,7 @@ export class FlowService {
         ...processedResponse
       }
     } catch (error) {
-      console.error('Error invoking flow:', error)
+      log.error('Error invoking flow:', error)
       throw error
     }
   }
@@ -176,7 +177,7 @@ export class FlowService {
         }
       }
     } catch (error: any) {
-      console.error('Error processing response stream:', error)
+      log.error('Error processing response stream:', error)
 
       // セッションコンテキストエラーの場合は特別なハンドリング
       if (

--- a/src/main/api/bedrock/services/imageService.ts
+++ b/src/main/api/bedrock/services/imageService.ts
@@ -1,6 +1,7 @@
 import { BedrockRuntimeClient, InvokeModelCommand } from '@aws-sdk/client-bedrock-runtime'
 import type { ServiceContext } from '../types'
 import { createRuntimeClient } from '../client'
+import { log } from '../../../../common/logger'
 import type {
   AspectRatio,
   GenerateImageRequest,
@@ -119,7 +120,7 @@ export class ImageService {
       (!awsCredentials.useProfile &&
         (!awsCredentials.accessKeyId || !awsCredentials.secretAccessKey))
     ) {
-      console.warn('AWS credentials not configured properly')
+      log.warn('AWS credentials not configured properly')
     }
 
     this.runtimeClient = createRuntimeClient(awsCredentials)
@@ -328,7 +329,7 @@ export class ImageService {
 
       throw new Error('Unsupported model type')
     } catch (error: any) {
-      console.error('Error generating image:', error)
+      log.error('Error generating image:', error)
       if (error.name === 'UnrecognizedClientException') {
         throw new Error('AWS authentication failed. Please check your credentials and permissions.')
       }

--- a/src/main/api/bedrock/services/modelService.ts
+++ b/src/main/api/bedrock/services/modelService.ts
@@ -2,6 +2,7 @@ import { getDefaultPromptRouter, getModelsForRegion } from '../models'
 import { getAccountId } from '../utils/awsUtils'
 import type { ServiceContext, AWSCredentials } from '../types'
 import { BedrockSupportRegion } from '../../../../types/llm'
+import { log } from '../../../../common/logger'
 
 export class ModelService {
   constructor(private context: ServiceContext) {}
@@ -12,7 +13,7 @@ export class ModelService {
 
     // AWS認証情報のバリデーション
     if (!region || (!useProfile && !accessKeyId)) {
-      console.warn('AWS credentials not configured properly')
+      log.warn('AWS credentials not configured properly')
       return []
     }
 
@@ -24,7 +25,7 @@ export class ModelService {
 
       return result
     } catch (error) {
-      console.error('Error in listModels:', error)
+      log.error('Error in listModels:', error)
       return []
     }
   }

--- a/src/main/api/bedrock/utils/awsUtils.ts
+++ b/src/main/api/bedrock/utils/awsUtils.ts
@@ -3,6 +3,7 @@ import type { AWSCredentials } from '../types'
 import { allModels } from '../models'
 import type { LLM } from '../../../../types/llm'
 import { fromIni } from '@aws-sdk/credential-providers'
+import { log } from '../../../../common/logger'
 
 /**
  * 指定されたモデルIDに対応するモデル情報を取得する
@@ -70,7 +71,7 @@ export async function getAccountId(awsCredentials: AWSCredentials) {
     const res = await sts.send(command)
     return res.Account
   } catch (error) {
-    console.error('Error getting AWS account ID:', error)
+    log.error('Error getting AWS account ID:', error)
     return null
   }
 }

--- a/src/main/api/command/commandService.ts
+++ b/src/main/api/command/commandService.ts
@@ -10,6 +10,7 @@ import {
   ProcessState,
   CommandPatternConfig
 } from './types'
+import { log } from '../../../common/logger'
 
 export class CommandService {
   private config: CommandConfig
@@ -282,7 +283,7 @@ Shell: ${this.config.shell}
 Command: ${input.command}
 Working Directory: ${input.cwd}
 Spawn Method: ${isWindows ? 'shell=true' : 'shell+args'}`
-        console.error('Process spawn failed:', {
+        log.error('Process spawn failed:', {
           platform: process.platform,
           shell: this.config.shell,
           command: input.command,

--- a/src/main/api/sonic/regionCheck.ts
+++ b/src/main/api/sonic/regionCheck.ts
@@ -1,5 +1,6 @@
 import { isNovaSonicSupportedRegion, getNovaSonicSupportedRegions } from './constants'
 import { store } from '../../../preload/store'
+import { log } from '../../../common/logger'
 
 export interface RegionCheckResult {
   isSupported: boolean
@@ -61,7 +62,7 @@ export async function testBedrockConnectivity(region?: string): Promise<{
     // For now, we just validate that credentials exist and region is specified
     // A more comprehensive test would require making an actual API call, but that might be expensive
     // and could fail due to network issues rather than configuration problems
-    console.log(`Testing connectivity for region: ${currentRegion}`)
+    log.debug('Testing connectivity for region', { currentRegion })
     return {
       success: true
     }

--- a/src/main/handlers/agent-handlers.ts
+++ b/src/main/handlers/agent-handlers.ts
@@ -87,7 +87,9 @@ async function loadSharedAgents(): Promise<{ agents: CustomAgent[]; error: strin
 
     return { agents, error: null }
   } catch (error) {
-    console.error('Error reading shared agents:', error)
+    agentsLogger.error('Error reading shared agents', {
+      error: error instanceof Error ? error.message : String(error)
+    })
     return { agents: [], error: error instanceof Error ? error.message : String(error) }
   }
 }
@@ -178,7 +180,9 @@ export const agentHandlers = {
 
       return { success: true, filePath, format }
     } catch (error) {
-      console.error('Error saving shared agent:', error)
+      agentsLogger.error('Error saving shared agent', {
+        error: error instanceof Error ? error.message : String(error)
+      })
       return {
         success: false,
         error: error instanceof Error ? error.message : String(error)

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -44,7 +44,7 @@ import('fix-path')
     fixPathModule.default()
   })
   .catch((err) => {
-    console.error('Failed to load fix-path module:', err)
+    log.error('Failed to load fix-path module:', { error: err })
   })
 
 // No need to track project path anymore as we always read from disk
@@ -82,7 +82,7 @@ async function setupSessionProxy(window: BrowserWindow): Promise<void> {
 
     // プロキシ設定を決定
     const proxyConfig = resolveProxyConfig(awsConfig?.proxyConfig)
-    console.log({ proxyConfig })
+    log.debug('Resolved proxy configuration', { proxyConfig })
 
     if (proxyConfig) {
       const electronProxyRules = convertToElectronProxyConfig(proxyConfig)

--- a/src/main/services/strandsAgentsConverter/StrandsAgentsConverter.ts
+++ b/src/main/services/strandsAgentsConverter/StrandsAgentsConverter.ts
@@ -4,13 +4,9 @@ import { CodeGenerator } from './codeGenerator'
 import { TOOL_MAPPING } from './toolMapper'
 import { promises as fs } from 'fs'
 import * as path from 'path'
+import { createCategoryLogger } from '../../../common/logger'
 
-// Simple logger
-const logger = {
-  info: (message: string) => console.log(`[INFO] ${message}`),
-  warn: (message: string) => console.warn(`[WARN] ${message}`),
-  error: (message: string, error?: any) => console.error(`[ERROR] ${message}`, error || '')
-}
+const logger = createCategoryLogger('strands-converter')
 
 /**
  * Service to convert Bedrock Engineer's CustomAgent to Strands Agents code

--- a/src/main/store/chatSession.ts
+++ b/src/main/store/chatSession.ts
@@ -3,6 +3,7 @@ import fs from 'fs'
 import Store from 'electron-store'
 import { ChatSession, ChatMessage, SessionMetadata } from '../../types/chat/history'
 import { store } from '../../preload/store'
+import { log } from '../../common/logger'
 
 export class ChatSessionManager {
   private readonly sessionsDir: string
@@ -50,9 +51,9 @@ export class ChatSessionManager {
           }
         }
 
-        console.log('Metadata initialized successfully')
+        log.debug('Metadata initialized successfully')
       } catch (error) {
-        console.error('Error initializing metadata:', error)
+        log.error('Error initializing metadata:', error)
       }
     }
   }
@@ -67,7 +68,7 @@ export class ChatSessionManager {
       const data = fs.readFileSync(filePath, 'utf-8')
       return JSON.parse(data) as ChatSession
     } catch (error) {
-      console.error(`Error reading session file ${sessionId}:`, error)
+      log.error(`Error reading session file ${sessionId}:`, error)
       return null
     }
   }
@@ -77,7 +78,7 @@ export class ChatSessionManager {
     try {
       await fs.promises.writeFile(filePath, JSON.stringify(session, null, 2))
     } catch (error) {
-      console.error(`Error writing session file ${sessionId}:`, error)
+      log.error(`Error writing session file ${sessionId}:`, error)
     }
   }
 
@@ -155,7 +156,7 @@ export class ChatSessionManager {
       delete metadata[sessionId]
       this.metadataStore.set('metadata', metadata)
     } catch (error) {
-      console.error(`Error deleting session file ${sessionId}:`, error)
+      log.error(`Error deleting session file ${sessionId}:`, error)
     }
 
     const recentSessions = this.metadataStore.get('recentSessions')
@@ -181,9 +182,9 @@ export class ChatSessionManager {
       this.metadataStore.set('recentSessions', [])
       this.metadataStore.delete('activeSessionId')
 
-      console.log('All sessions have been deleted successfully')
+      log.debug('All sessions have been deleted successfully')
     } catch (error) {
-      console.error('Error deleting all sessions:', error)
+      log.error('Error deleting all sessions:', error)
     }
   }
 
@@ -237,7 +238,7 @@ export class ChatSessionManager {
 
     // 指定されたインデックスが有効な範囲内かチェック
     if (messageIndex < 0 || messageIndex >= session.messages.length) {
-      console.error(`Invalid message index: ${messageIndex}`)
+      log.error(`Invalid message index: ${messageIndex}`)
       return
     }
 
@@ -256,7 +257,7 @@ export class ChatSessionManager {
 
     // 指定されたインデックスが有効な範囲内かチェック
     if (messageIndex < 0 || messageIndex >= session.messages.length) {
-      console.error(`Invalid message index: ${messageIndex}`)
+      log.error(`Invalid message index: ${messageIndex}`)
       return
     }
 

--- a/src/main/store/todoSession.ts
+++ b/src/main/store/todoSession.ts
@@ -2,6 +2,7 @@ import path from 'path'
 import fs from 'fs'
 import Store from 'electron-store'
 import { store } from '../../preload/store'
+import { log } from '../../common/logger'
 
 export interface TodoItem {
   id: string
@@ -88,9 +89,9 @@ export class TodoSessionManager {
           }
         }
 
-        console.log('Todo metadata initialized successfully')
+        log.debug('Todo metadata initialized successfully')
       } catch (error) {
-        console.error('Error initializing todo metadata:', error)
+        log.error('Error initializing todo metadata:', error)
       }
     }
   }
@@ -109,7 +110,7 @@ export class TodoSessionManager {
       const data = fs.readFileSync(filePath, 'utf-8')
       return JSON.parse(data) as TodoList
     } catch (error) {
-      console.error(`Error reading todo file ${sessionId}:`, error)
+      log.error(`Error reading todo file ${sessionId}:`, error)
       return null
     }
   }
@@ -119,7 +120,7 @@ export class TodoSessionManager {
     try {
       await fs.promises.writeFile(filePath, JSON.stringify(todoList, null, 2))
     } catch (error) {
-      console.error(`Error writing todo file ${sessionId}:`, error)
+      log.error(`Error writing todo file ${sessionId}:`, error)
     }
   }
 
@@ -234,7 +235,7 @@ export class TodoSessionManager {
       delete metadata[sessionId]
       this.metadataStore.set('metadata', metadata)
     } catch (error) {
-      console.error(`Error deleting todo file ${sessionId}:`, error)
+      log.error(`Error deleting todo file ${sessionId}:`, error)
     }
 
     const recentTodos = this.metadataStore.get('recentTodos')


### PR DESCRIPTION
## Summary
- remove direct console logging across main process
- switch to category loggers in Sonic client and Strands converter
- use `log.debug`/`log.error` in various services and stores
- update proxy setup logs in `index.ts`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6889c19b44408331a2aa3dbe3b5652ab