### PR TITLE
Restrict integration test env logging

### DIFF
--- a/jest.integration.setup.js
+++ b/jest.integration.setup.js
@@ -1,10 +1,9 @@
 require('dotenv').config()
 
 // Add any additional setup code here
-console.log('Integration test environment variables loaded:', {
-  AWS_REGION: process.env.AWS_REGION,
-  INTEGRATION_TEST: process.env.INTEGRATION_TEST,
-  // Mask sensitive credentials in logs
-  AWS_ACCESS_KEY_ID: process.env.AWS_ACCESS_KEY_ID ? '***' : undefined,
-  AWS_SECRET_ACCESS_KEY: process.env.AWS_SECRET_ACCESS_KEY ? '***' : undefined
-})
+
+// Only log the presence of non-sensitive environment keys to avoid leaking values
+const SAFE_ENV_KEYS = ['AWS_REGION', 'INTEGRATION_TEST']
+const presentKeys = SAFE_ENV_KEYS.filter((key) => process.env[key] !== undefined)
+
+console.log('Integration test environment variables loaded:', presentKeys)


### PR DESCRIPTION
## Summary
- log only presence of safe environment keys during integration test setup to prevent leaking secrets

## Testing
- `npm test`
- `npm run test:integration` *(fails: TS1378, TS2345 errors and missing Docker)*

------
https://chatgpt.com/codex/tasks/task_e_6892c0a7beec833190879db9dd00aa6c