### PR TITLE
feat: configure allowed origins

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,6 @@
+# Application Configuration
+ALLOWED_ORIGINS=http://localhost:5173
+
 # AWS Credentials
 AWS_ACCESS_KEY_ID=your_access_key_here
 AWS_SECRET_ACCESS_KEY=your_secret_key_here

--- a/src/main/api/index.ts
+++ b/src/main/api/index.ts
@@ -47,7 +47,9 @@ const errorHandler: ErrorRequestHandler = (err, req, res, _next) => {
 const api = express()
 const server = http.createServer(api)
 
-const allowedOrigins = ['http://localhost:5173']
+const allowedOrigins = process.env.ALLOWED_ORIGINS
+  ? process.env.ALLOWED_ORIGINS.split(',').map((origin) => origin.trim())
+  : ['http://localhost:5173']
 const io = new Server(server, {
   cors: {
     origin: allowedOrigins,


### PR DESCRIPTION
## Summary
- make API CORS allowed origins configurable via env
- document `ALLOWED_ORIGINS` in sample env file

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6892c91dd5148331ae9ae55489d56838