### PR TITLE
feat: add URL validation and safety checks

### DIFF
--- a/src/main/lib/url-utils.ts
+++ b/src/main/lib/url-utils.ts
@@ -1,16 +1,95 @@
+import dns from 'dns/promises'
+import net from 'node:net'
+
+/**
+ * List of hosts that are considered trusted. If empty, all hosts are allowed
+ * (subject to other validation rules).
+ */
 const ALLOWED_HOSTS = ['github.com']
 
-export function isUrlAllowed(targetUrl: string): boolean {
+/**
+ * Checks if a URL uses http/https schemes and optionally if it belongs to the
+ * list of trusted hosts. This check is synchronous and does not perform any
+ * network lookups. It is used in places where a quick validation is required
+ * (e.g. Electron navigation handling).
+ */
+export function isUrlAllowed(targetUrl: string, allowedHosts: string[] = ALLOWED_HOSTS): boolean {
   try {
     const { protocol, hostname } = new URL(targetUrl)
-    if (protocol !== 'https:') {
+    if (protocol !== 'http:' && protocol !== 'https:') {
       return false
     }
-    return ALLOWED_HOSTS.includes(hostname)
+    if (allowedHosts.length > 0 && !allowedHosts.includes(hostname)) {
+      return false
+    }
+    return true
+  } catch {
+    return false
+  }
+}
+
+function isPrivateIpv4(ip: string): boolean {
+  const parts = ip.split('.').map((part) => Number(part))
+  return (
+    parts[0] === 10 ||
+    parts[0] === 127 ||
+    (parts[0] === 169 && parts[1] === 254) ||
+    (parts[0] === 192 && parts[1] === 168) ||
+    (parts[0] === 172 && parts[1] >= 16 && parts[1] <= 31)
+  )
+}
+
+function isPrivateIpv6(ip: string): boolean {
+  const normalized = ip.toLowerCase()
+  return (
+    normalized === '::1' ||
+    normalized.startsWith('fc') ||
+    normalized.startsWith('fd') ||
+    normalized.startsWith('fe80')
+  )
+}
+
+function isPrivateIp(ip: string): boolean {
+  const ipVersion = net.isIP(ip)
+  if (ipVersion === 4) {
+    return isPrivateIpv4(ip)
+  }
+  if (ipVersion === 6) {
+    return isPrivateIpv6(ip)
+  }
+  return false
+}
+
+async function resolvesToPrivateIp(hostname: string): Promise<boolean> {
+  if (net.isIP(hostname)) {
+    return isPrivateIp(hostname)
+  }
+  try {
+    const addresses = await dns.lookup(hostname, { all: true })
+    return addresses.some((addr) => isPrivateIp(addr.address))
+  } catch {
+    // If the lookup fails, assume it could be unsafe
+    return true
+  }
+}
+
+/**
+ * Comprehensive URL safety check that validates the scheme, optional allowed
+ * hosts and ensures the host does not resolve to a private network address.
+ */
+export async function isUrlSafe(
+  targetUrl: string,
+  allowedHosts: string[] = ALLOWED_HOSTS
+): Promise<boolean> {
+  if (!isUrlAllowed(targetUrl, allowedHosts)) {
+    return false
+  }
+  try {
+    const { hostname } = new URL(targetUrl)
+    return !(await resolvesToPrivateIp(hostname))
   } catch {
     return false
   }
 }
 
 export { ALLOWED_HOSTS }
-

--- a/src/test/src/main/url-utils.test.ts
+++ b/src/test/src/main/url-utils.test.ts
@@ -1,16 +1,30 @@
-import { isUrlAllowed } from '../../../main/lib/url-utils'
+import dns from 'dns/promises'
+import { isUrlSafe } from '../../../main/lib/url-utils'
 
-describe('isUrlAllowed', () => {
-  test('rejects non-HTTPS URLs', () => {
-    expect(isUrlAllowed('http://github.com')).toBe(false)
+jest.mock('dns/promises')
+
+const lookupMock = dns.lookup as jest.MockedFunction<typeof dns.lookup>
+
+describe('isUrlSafe', () => {
+  beforeEach(() => {
+    lookupMock.mockReset()
   })
 
-  test('rejects non-whitelisted URLs', () => {
-    expect(isUrlAllowed('https://example.com')).toBe(false)
+  test('rejects non-http/https URLs', async () => {
+    expect(await isUrlSafe('ftp://github.com')).toBe(false)
   })
 
-  test('allows whitelisted HTTPS URLs', () => {
-    expect(isUrlAllowed('https://github.com')).toBe(true)
+  test('rejects non-whitelisted URLs', async () => {
+    lookupMock.mockResolvedValue([{ address: '1.1.1.1', family: 4 }] as any)
+    expect(await isUrlSafe('https://example.com')).toBe(false)
+  })
+
+  test('rejects private network URLs', async () => {
+    expect(await isUrlSafe('http://127.0.0.1')).toBe(false)
+  })
+
+  test('allows whitelisted HTTP URLs', async () => {
+    lookupMock.mockResolvedValue([{ address: '1.1.1.1', family: 4 }] as any)
+    expect(await isUrlSafe('http://github.com')).toBe(true)
   })
 })
-


### PR DESCRIPTION
## Summary
- validate URL schemes against optional trust list and block private network addresses
- enforce request timeouts and safety checks for website fetches
- test allowed and rejected URL cases

## Testing
- `npm test -- src/test/src/main/url-utils.test.ts`
- `npx eslint src/main/lib/url-utils.ts src/test/src/main/url-utils.test.ts src/main/handlers/util-handlers.ts`


------
https://chatgpt.com/codex/tasks/task_e_689943bb8c5c8331960fd3cb07603adf