### PR TITLE
refactor: externalize styles and tighten csp

### DIFF
--- a/src/renderer/camera-preview.css
+++ b/src/renderer/camera-preview.css
@@ -1,0 +1,190 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  background-color: rgba(0, 0, 0, 0.1);
+  overflow: hidden;
+  user-select: none;
+  -webkit-user-select: none;
+}
+
+.preview-container {
+  position: relative;
+  width: 100%;
+  height: 100vh;
+  background: linear-gradient(45deg, rgba(0, 0, 0, 0.8), rgba(0, 0, 0, 0.6));
+  border-radius: 12px;
+  overflow: hidden;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.3);
+  border: 2px solid rgba(255, 255, 255, 0.1);
+}
+
+.video-stream {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: 10px;
+}
+
+.controls-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 30px;
+  background: linear-gradient(to bottom, rgba(0, 0, 0, 0.7), transparent);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 8px;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+  z-index: 10;
+}
+
+.preview-container:hover .controls-overlay {
+  opacity: 1;
+}
+
+.control-button {
+  background: rgba(255, 255, 255, 0.2);
+  border: none;
+  border-radius: 4px;
+  color: white;
+  font-size: 12px;
+  padding: 4px 6px;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+  backdrop-filter: blur(10px);
+  -webkit-app-region: no-drag;
+}
+
+.control-button:hover {
+  background: rgba(255, 255, 255, 0.3);
+}
+
+.status-indicator {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  z-index: 10;
+  animation: pulse 2s infinite;
+}
+
+.status-indicator.status-active {
+  background: #22c55e;
+}
+
+.status-indicator.status-loading {
+  background: #f59e0b;
+}
+
+.status-indicator.status-error {
+  background: #ef4444;
+}
+
+.status-indicator.status-default {
+  background: #6b7280;
+}
+
+@keyframes pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.5;
+  }
+}
+
+.error-message {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  color: white;
+  text-align: center;
+  font-size: 14px;
+  padding: 20px;
+  background: rgba(239, 68, 68, 0.9);
+  border-radius: 8px;
+  z-index: 20;
+}
+
+.warning-message {
+  background: rgba(245, 158, 11, 0.9);
+}
+
+.loading-message {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  color: white;
+  text-align: center;
+  font-size: 14px;
+  z-index: 20;
+}
+
+.loading-spinner {
+  display: inline-block;
+  width: 20px;
+  height: 20px;
+  border: 2px solid rgba(255, 255, 255, 0.3);
+  border-radius: 50%;
+  border-top-color: white;
+  animation: spin 1s ease-in-out infinite;
+  margin-bottom: 8px;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.camera-info {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background: linear-gradient(to top, rgba(0, 0, 0, 0.7), transparent);
+  color: white;
+  font-size: 11px;
+  padding: 8px;
+  text-align: center;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+}
+
+.preview-container:hover .camera-info {
+  opacity: 1;
+}
+
+/* ドラッグ可能エリア */
+.drag-handle {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 100%;
+  z-index: 5;
+  cursor: move;
+  -webkit-app-region: drag;
+}
+
+.hidden {
+  display: none;
+}
+
+.error-details {
+  font-size: 12px;
+  margin-top: 8px;
+}

--- a/src/renderer/camera-preview.html
+++ b/src/renderer/camera-preview.html
@@ -7,175 +7,9 @@
     <!-- https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP -->
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' https: data:"
+      content="default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' https: data:"
     />
-    <style>
-      * {
-        margin: 0;
-        padding: 0;
-        box-sizing: border-box;
-      }
-
-      body {
-        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-        background-color: rgba(0, 0, 0, 0.1);
-        overflow: hidden;
-        user-select: none;
-        -webkit-user-select: none;
-      }
-
-      .preview-container {
-        position: relative;
-        width: 100%;
-        height: 100vh;
-        background: linear-gradient(45deg, rgba(0, 0, 0, 0.8), rgba(0, 0, 0, 0.6));
-        border-radius: 12px;
-        overflow: hidden;
-        box-shadow: 0 8px 24px rgba(0, 0, 0, 0.3);
-        border: 2px solid rgba(255, 255, 255, 0.1);
-      }
-
-      .video-stream {
-        width: 100%;
-        height: 100%;
-        object-fit: cover;
-        border-radius: 10px;
-      }
-
-      .controls-overlay {
-        position: absolute;
-        top: 0;
-        left: 0;
-        right: 0;
-        height: 30px;
-        background: linear-gradient(to bottom, rgba(0, 0, 0, 0.7), transparent);
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-        padding: 0 8px;
-        opacity: 0;
-        transition: opacity 0.3s ease;
-        z-index: 10;
-      }
-
-      .preview-container:hover .controls-overlay {
-        opacity: 1;
-      }
-
-      .control-button {
-        background: rgba(255, 255, 255, 0.2);
-        border: none;
-        border-radius: 4px;
-        color: white;
-        font-size: 12px;
-        padding: 4px 6px;
-        cursor: pointer;
-        transition: background-color 0.2s ease;
-        backdrop-filter: blur(10px);
-      }
-
-      .control-button:hover {
-        background: rgba(255, 255, 255, 0.3);
-      }
-
-      .status-indicator {
-        position: absolute;
-        top: 8px;
-        right: 8px;
-        width: 8px;
-        height: 8px;
-        background: #22c55e;
-        border-radius: 50%;
-        z-index: 10;
-        animation: pulse 2s infinite;
-      }
-
-      @keyframes pulse {
-        0%,
-        100% {
-          opacity: 1;
-        }
-        50% {
-          opacity: 0.5;
-        }
-      }
-
-      .error-message {
-        position: absolute;
-        top: 50%;
-        left: 50%;
-        transform: translate(-50%, -50%);
-        color: white;
-        text-align: center;
-        font-size: 14px;
-        padding: 20px;
-        background: rgba(239, 68, 68, 0.9);
-        border-radius: 8px;
-        z-index: 20;
-      }
-
-      .loading-message {
-        position: absolute;
-        top: 50%;
-        left: 50%;
-        transform: translate(-50%, -50%);
-        color: white;
-        text-align: center;
-        font-size: 14px;
-        z-index: 20;
-      }
-
-      .loading-spinner {
-        display: inline-block;
-        width: 20px;
-        height: 20px;
-        border: 2px solid rgba(255, 255, 255, 0.3);
-        border-radius: 50%;
-        border-top-color: white;
-        animation: spin 1s ease-in-out infinite;
-        margin-bottom: 8px;
-      }
-
-      @keyframes spin {
-        to {
-          transform: rotate(360deg);
-        }
-      }
-
-      .camera-info {
-        position: absolute;
-        bottom: 0;
-        left: 0;
-        right: 0;
-        background: linear-gradient(to top, rgba(0, 0, 0, 0.7), transparent);
-        color: white;
-        font-size: 11px;
-        padding: 8px;
-        text-align: center;
-        opacity: 0;
-        transition: opacity 0.3s ease;
-      }
-
-      .preview-container:hover .camera-info {
-        opacity: 1;
-      }
-
-      /* ドラッグ可能エリア */
-      .drag-handle {
-        position: absolute;
-        top: 0;
-        left: 0;
-        right: 0;
-        height: 100%;
-        z-index: 5;
-        cursor: move;
-        -webkit-app-region: drag;
-      }
-
-      .control-button {
-        -webkit-app-region: no-drag;
-      }
-    </style>
+    <link rel="stylesheet" href="camera-preview.css" />
   </head>
   <body>
     <div class="preview-container" id="previewContainer">
@@ -189,7 +23,7 @@
       </div>
 
       <!-- ステータスインジケーター -->
-      <div class="status-indicator" id="statusIndicator"></div>
+      <div class="status-indicator status-default" id="statusIndicator"></div>
 
       <!-- ビデオストリーム -->
       <video class="video-stream" id="videoStream" autoplay muted playsinline></video>
@@ -201,9 +35,9 @@
       </div>
 
       <!-- エラーメッセージ -->
-      <div class="error-message" id="errorMessage" style="display: none">
+      <div class="error-message hidden" id="errorMessage">
         <div>Camera access failed</div>
-        <div style="font-size: 12px; margin-top: 8px" id="errorDetails"></div>
+        <div class="error-details" id="errorDetails"></div>
       </div>
 
       <!-- カメラ情報 -->
@@ -409,18 +243,18 @@
         }
 
         showLoading() {
-          this.loadingMessage.style.display = 'block'
-          this.errorMessage.style.display = 'none'
+          this.loadingMessage.classList.remove('hidden')
+          this.errorMessage.classList.add('hidden')
           this.updateStatus('loading')
         }
 
         hideLoading() {
-          this.loadingMessage.style.display = 'none'
+          this.loadingMessage.classList.add('hidden')
         }
 
         showError(title, details) {
-          this.loadingMessage.style.display = 'none'
-          this.errorMessage.style.display = 'block'
+          this.loadingMessage.classList.add('hidden')
+          this.errorMessage.classList.remove('hidden')
           this.errorMessage.firstElementChild.textContent = title
           this.errorDetails.textContent = details
           this.updateStatus('error')
@@ -430,13 +264,13 @@
           log.warn(`${title}: ${details}`)
           // 警告は一時的に表示して自動で消える
           const warningElement = this.errorMessage.cloneNode(true)
-          warningElement.style.background = 'rgba(245, 158, 11, 0.9)' // 警告色（オレンジ）
+          warningElement.classList.add('warning-message')
+          warningElement.classList.remove('hidden')
           warningElement.firstElementChild.textContent = title
           warningElement.children[1].textContent = details
 
-          this.loadingMessage.style.display = 'none'
-          this.errorMessage.style.display = 'none'
-          warningElement.style.display = 'block'
+          this.loadingMessage.classList.add('hidden')
+          this.errorMessage.classList.add('hidden')
 
           // 警告要素を一時的に追加
           document.getElementById('previewContainer').appendChild(warningElement)
@@ -453,22 +287,24 @@
         }
 
         hideError() {
-          this.errorMessage.style.display = 'none'
+          this.errorMessage.classList.add('hidden')
         }
 
         updateStatus(status) {
+          const classes = ['status-active', 'status-loading', 'status-error', 'status-default']
+          this.statusIndicator.classList.remove(...classes)
           switch (status) {
             case 'active':
-              this.statusIndicator.style.background = '#22c55e'
+              this.statusIndicator.classList.add('status-active')
               break
             case 'loading':
-              this.statusIndicator.style.background = '#f59e0b'
+              this.statusIndicator.classList.add('status-loading')
               break
             case 'error':
-              this.statusIndicator.style.background = '#ef4444'
+              this.statusIndicator.classList.add('status-error')
               break
             default:
-              this.statusIndicator.style.background = '#6b7280'
+              this.statusIndicator.classList.add('status-default')
           }
         }
 

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -6,7 +6,7 @@
     <!-- https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP -->
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' https: data:"
+      content="default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' https: data:"
     />
   </head>
 


### PR DESCRIPTION
## Summary
- externalize camera preview styling into dedicated CSS file
- remove `unsafe-inline` from renderer CSP directives
- replace inline style mutations with class-based updates

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689957638ccc8331a927493da72cb6c4