### PR TITLE
feat: add global rate limiting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "electron-store": "8.2.0",
         "electron-updater": "^6.3.9",
         "express": "^4.21.2",
+        "express-rate-limit": "^8.0.1",
         "fix-path": "^4.0.0",
         "flowbite-react": "0.10.1",
         "framer-motion": "11.3.29",
@@ -8265,6 +8266,21 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/express-rate-limit": {
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.1.tgz",
+      "integrity": "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/@modelcontextprotocol/sdk/node_modules/finalhandler": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.0.tgz",
@@ -16058,10 +16074,13 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.1.tgz",
-      "integrity": "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.0.1.tgz",
+      "integrity": "sha512-aZVCnybn7TVmxO4BtlmnvX+nuz8qHW124KKJ8dumsBsmv5ZLxE0pYu7S2nwyRBGHHCAzdmnGyrc5U/rksSPO7Q==",
       "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.0.1"
+      },
       "engines": {
         "node": ">= 16"
       },
@@ -17932,6 +17951,15 @@
       "resolved": "https://registry.npmjs.org/intersection-observer/-/intersection-observer-0.10.0.tgz",
       "integrity": "sha512-fn4bQ0Xq8FTej09YC/jqKZwtijpvARlRp6wxL5WTA6yPe2YWSJ5RJh7Nm79rK2qB0wr6iDQzH60XGq5V/7u8YQ==",
       "license": "W3C-20150513"
+    },
+    "node_modules/ip-address": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
+      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "electron-store": "8.2.0",
     "electron-updater": "^6.3.9",
     "express": "^4.21.2",
+    "express-rate-limit": "^8.0.1",
     "fix-path": "^4.0.0",
     "flowbite-react": "0.10.1",
     "framer-motion": "11.3.29",

--- a/src/main/api/index.ts
+++ b/src/main/api/index.ts
@@ -2,6 +2,7 @@ import express, { Request, Response, ErrorRequestHandler } from 'express'
 import cors from 'cors'
 import compression from 'compression'
 import helmet from 'helmet'
+import rateLimit from 'express-rate-limit'
 import { RequestHandler, NextFunction } from 'express'
 import { RetrieveAndGenerateCommandInput } from '@aws-sdk/client-bedrock-agent-runtime'
 import { BedrockService, CallConverseAPIProps } from './bedrock'
@@ -46,6 +47,18 @@ const errorHandler: ErrorRequestHandler = (err, req, res, _next) => {
 // アプリケーションで動作するようにdotenvを設定する
 const api = express()
 const server = http.createServer(api)
+
+const rateLimitWindowMs = parseInt(
+  process.env.RATE_LIMIT_WINDOW_MS || String(15 * 60 * 1000),
+  10
+)
+const rateLimitMax = parseInt(process.env.RATE_LIMIT_MAX || '100', 10)
+api.use(
+  rateLimit({
+    windowMs: rateLimitWindowMs,
+    max: rateLimitMax
+  })
+)
 
 const allowedOrigins = process.env.ALLOWED_ORIGINS
   ? process.env.ALLOWED_ORIGINS.split(',').map((origin) => origin.trim())


### PR DESCRIPTION
## Summary
- add express-rate-limit dependency
- apply configurable global request limiter

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689961dbda0883318b68fc7bdb9c1c18