### PR TITLE
fix: sanitize JSON viewer and add tests

### DIFF
--- a/src/renderer/src/components/JSONViewer/__tests__/JSONViewer.test.ts
+++ b/src/renderer/src/components/JSONViewer/__tests__/JSONViewer.test.ts
@@ -1,0 +1,33 @@
+/** @jest-environment jsdom */
+
+import React from 'react'
+import { describe, expect, test } from '@jest/globals'
+import JSONViewer from '..'
+import { TextEncoder, TextDecoder } from 'util'
+
+// Polyfill for environments where these are missing (e.g., jsdom)
+;(global as any).TextEncoder = TextEncoder
+;(global as any).TextDecoder = TextDecoder
+
+// Import after polyfills to avoid ReferenceError in react-dom/server
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { renderToString } = require('react-dom/server')
+
+describe('JSONViewer sanitization', () => {
+  test('renders script tags as harmless text', () => {
+    const data = { message: '<script>alert("xss")</script>' }
+    const html = renderToString(
+      React.createElement(JSONViewer, {
+        data,
+        title: '',
+        showCopyButton: false
+      })
+    )
+
+    const container = document.createElement('div')
+    container.innerHTML = html
+
+    expect(container.querySelector('script')).toBeNull()
+    expect(container.textContent).not.toContain('alert("xss")')
+  })
+})

--- a/src/renderer/src/components/JSONViewer/index.tsx
+++ b/src/renderer/src/components/JSONViewer/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import toast from 'react-hot-toast'
 import { useTranslation } from 'react-i18next'
+import DOMPurify from 'dompurify'
 
 interface JSONViewerProps {
   /**
@@ -32,29 +33,49 @@ export const JSONViewer: React.FC<JSONViewerProps> = ({
 }) => {
   const { t } = useTranslation()
 
-  // JSONをハイライト適用して整形する
+  // JSON文字列をサニタイズして安全にハイライトする
   const highlightedJson = React.useMemo(() => {
     const jsonStr = JSON.stringify(data, null, 2)
+    const sanitized = DOMPurify.sanitize(jsonStr)
 
-    return (
-      jsonStr
-        // キーの色を変更（"key": の部分）
-        .replace(/"([^"]+)":/g, '<span class="text-indigo-600 dark:text-indigo-400">"$1"</span>:')
-        // 文字列値の色を変更（": "value" の部分）
-        .replace(/: "([^"]*)"/g, ': <span class="text-green-600 dark:text-green-400">"$1"</span>')
-        // 数値の色を変更
-        .replace(/: (\\d+)(,?)/g, ': <span class="text-blue-600 dark:text-blue-400">$1</span>$2')
-        // ブール値の色を変更
-        .replace(
-          /: (true|false)(,?)/g,
-          ': <span class="text-yellow-600 dark:text-yellow-400">$1</span>$2'
-        )
-        // nullの色を変更
-        .replace(
-          /: (null)(,?)/g,
-          ': <span class="text-purple-600 dark:text-purple-400">$1</span>$2'
-        )
-    )
+    const elements: React.ReactNode[] = []
+    const regex =
+      /("(?:\\u[a-fA-F0-9]{4}|\\[^u]|[^\\"])*"(?:\s*:)?|\b(?:true|false|null)\b|-?\d+(?:\.\d*)?(?:[eE][+\-]?\d+)?)/g
+    let lastIndex = 0
+
+    sanitized.replace(regex, (match, _p1, offset) => {
+      if (lastIndex < offset) {
+        elements.push(sanitized.slice(lastIndex, offset))
+      }
+
+      let className = ''
+      if (/^"/.test(match)) {
+        className = /:$/.test(match)
+          ? 'text-indigo-600 dark:text-indigo-400'
+          : 'text-green-600 dark:text-green-400'
+      } else if (/true|false/.test(match)) {
+        className = 'text-yellow-600 dark:text-yellow-400'
+      } else if (/null/.test(match)) {
+        className = 'text-purple-600 dark:text-purple-400'
+      } else {
+        className = 'text-blue-600 dark:text-blue-400'
+      }
+
+      elements.push(
+        <span className={className} key={elements.length}>
+          {match}
+        </span>
+      )
+
+      lastIndex = offset + match.length
+      return match
+    })
+
+    if (lastIndex < sanitized.length) {
+      elements.push(sanitized.slice(lastIndex))
+    }
+
+    return elements
   }, [data])
 
   // クリップボードにJSONをコピー
@@ -97,8 +118,9 @@ export const JSONViewer: React.FC<JSONViewerProps> = ({
             scrollbar-track-gray-100 dark:scrollbar-track-gray-800
           `}
           style={{ maxHeight }}
-          dangerouslySetInnerHTML={{ __html: highlightedJson }}
-        />
+        >
+          {highlightedJson}
+        </pre>
 
         {showCopyButton && (
           <button

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -4,7 +4,12 @@
     "esModuleInterop": true,
     "types": ["jest", "node"],
     "module": "CommonJS",
-    "moduleResolution": "node"
+    "moduleResolution": "node",
+    "jsx": "react-jsx"
   },
-  "include": ["src/**/*.test.ts", "src/**/*.integration.test.ts"]
+  "include": [
+    "src/**/*.test.ts",
+    "src/**/*.integration.test.ts",
+    "src/**/*.test.tsx"
+  ]
 }


### PR DESCRIPTION
## Summary
- sanitize JSON output in JSONViewer with DOMPurify
- avoid dangerous regex string highlighting by generating React nodes
- add test ensuring script tags are rendered harmlessly

## Testing
- `npm test src/renderer/src/components/JSONViewer/__tests__/JSONViewer.test.ts`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899670b8e288331973d22f93290ba0f