### PR TITLE
Enable sandboxed camera preview window

### DIFF
--- a/src/main/handlers/camera-handlers.ts
+++ b/src/main/handlers/camera-handlers.ts
@@ -164,6 +164,7 @@ async function createPreviewWindow(
     webPreferences: {
       nodeIntegration: false,
       contextIsolation: true,
+      sandbox: true,
       preload: path.join(__dirname, '../preload/index.js'),
       webSecurity: true,
       additionalArguments: [`--camera-device-id=${deviceId}`, `--camera-device-name=${deviceName}`]

--- a/src/test/src/main/camera-handlers.security.test.ts
+++ b/src/test/src/main/camera-handlers.security.test.ts
@@ -1,0 +1,54 @@
+import type { BrowserWindowConstructorOptions } from 'electron'
+
+const loadFileMock = jest.fn().mockResolvedValue(undefined)
+const showMock = jest.fn()
+const onMock = jest.fn()
+const closeMock = jest.fn()
+
+const BrowserWindowMock = jest.fn().mockImplementation((_: BrowserWindowConstructorOptions) => ({
+  loadURL: jest.fn().mockResolvedValue(undefined),
+  loadFile: loadFileMock,
+  show: showMock,
+  close: closeMock,
+  on: onMock,
+  isDestroyed: jest.fn().mockReturnValue(false)
+}))
+
+jest.mock('electron', () => ({
+  BrowserWindow: BrowserWindowMock,
+  screen: {
+    getPrimaryDisplay: () => ({ workAreaSize: { width: 1920, height: 1080 } })
+  }
+}))
+
+jest.mock('../../../common/logger', () => ({
+  log: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn()
+  }
+}))
+
+import { cameraHandlers } from '../../../main/handlers/camera-handlers'
+
+describe('camera preview window security', () => {
+  beforeAll(() => {
+    ;(process as any).resourcesPath = __dirname
+  })
+
+  beforeEach(() => {
+    BrowserWindowMock.mockClear()
+  })
+
+  test('uses sandboxed renderer with isolation', async () => {
+    const result = await cameraHandlers['camera:show-preview-window']({} as any, { cameraIds: ['default'] })
+    expect(result.success).toBe(true)
+    expect(BrowserWindowMock).toHaveBeenCalled()
+    const opts = BrowserWindowMock.mock.calls[0][0]
+    expect(opts.webPreferences?.sandbox).toBe(true)
+    expect(opts.webPreferences?.nodeIntegration).toBe(false)
+    expect(opts.webPreferences?.contextIsolation).toBe(true)
+    expect(opts.webPreferences?.preload).toBeTruthy()
+  })
+})

--- a/src/test/src/preload/preload-sandbox.test.ts
+++ b/src/test/src/preload/preload-sandbox.test.ts
@@ -1,0 +1,48 @@
+import { jest } from '@jest/globals'
+
+describe('preload sandbox', () => {
+  test('exposes APIs in isolated context', () => {
+    const expose = jest.fn()
+    const originalContext = (process as any).contextIsolated
+
+    jest.isolateModules(() => {
+      ;(process as any).contextIsolated = true
+      jest.doMock('electron', () => ({
+        contextBridge: { exposeInMainWorld: expose },
+        ipcRenderer: { on: jest.fn(), send: jest.fn() }
+      }))
+      jest.doMock('@electron-toolkit/preload', () => ({ electronAPI: {} }))
+      jest.doMock('../../../preload/api', () => ({ api: {} }))
+      jest.doMock('../../../preload/store', () => ({ store: {} }))
+      jest.doMock('../../../preload/file', () => ({ file: {} }))
+      jest.doMock('../../../preload/chat-history', () => ({ chatHistory: {} }))
+      jest.doMock('../../../preload/appWindow', () => ({ appWindow: {} }))
+      jest.doMock('../../../preload/logger', () => ({
+        rendererLogger: {},
+        createRendererCategoryLogger: () => ({ info: jest.fn(), error: jest.fn(), debug: jest.fn() })
+      }))
+      jest.doMock('../../../preload/ipc-client', () => ({ ipcClient: {} }))
+      jest.doMock('../../../preload/tools', () => ({ executeTool: jest.fn() }))
+      jest.doMock('../../../preload/tools/registry', () => ({ ToolMetadataCollector: { getToolSpecs: jest.fn() } }))
+      require('../../../preload/index')
+    })
+
+    ;(process as any).contextIsolated = originalContext
+
+    expect(expose).toHaveBeenCalled()
+    const exposedKeys = expose.mock.calls.map((call) => call[0])
+    expect(exposedKeys).toEqual(
+      expect.arrayContaining([
+        'electron',
+        'api',
+        'store',
+        'file',
+        'chatHistory',
+        'appWindow',
+        'ipc',
+        'logger',
+        'preloadTools'
+      ])
+    )
+  })
+})


### PR DESCRIPTION
## Summary
- sandbox camera preview BrowserWindow to enforce renderer isolation
- add tests confirming sandboxed renderer and preload exposure

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899712d83a8833186fa8a44312c5bdf