### PR TITLE
Add connect-src CSP for API usage

### DIFF
--- a/src/renderer/camera-preview.html
+++ b/src/renderer/camera-preview.html
@@ -7,7 +7,7 @@
     <!-- https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP -->
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' https: data:"
+      content="default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' https: data:; connect-src 'self' https://api.example.com http://localhost:*"
     />
     <link rel="stylesheet" href="camera-preview.css" />
   </head>

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -6,7 +6,7 @@
     <!-- https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP -->
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' https: data:"
+      content="default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' https: data:; connect-src 'self' https://api.example.com http://localhost:*"
     />
   </head>
 


### PR DESCRIPTION
## Summary
- allow API connections in renderer CSP by adding connect-src for self, api.example.com, and localhost ports
- mirror CSP changes in camera preview page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68998133c5008331854761a91471848e