### PR TITLE
fix: refine CSP connect-src for local API and WebSocket

### DIFF
--- a/src/renderer/camera-preview.html
+++ b/src/renderer/camera-preview.html
@@ -7,7 +7,7 @@
     <!-- https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP -->
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' https: data:; connect-src 'self' https://api.example.com http://localhost:*"
+      content="default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' https: data:; connect-src 'self' http://localhost:* ws://localhost:*"
     />
     <link rel="stylesheet" href="camera-preview.css" />
   </head>

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -6,7 +6,7 @@
     <!-- https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP -->
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' https: data:; connect-src 'self' https://api.example.com http://localhost:*"
+      content="default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' https: data:; connect-src 'self' http://localhost:* ws://localhost:*"
     />
   </head>
 


### PR DESCRIPTION
## Summary
- allow local API and WebSocket connections in renderer CSP

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6899890ff0c08331bcc658d559d7da8b