### PR TITLE
refactor: move AIIcon styles to CSS module

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -46,6 +46,12 @@ export default [
         }
       ]
     }
+  },
+  {
+    files: ['**/*.{js,jsx,cjs,mjs}'],
+    rules: {
+      '@typescript-eslint/no-require-imports': 'off'
+    }
   }
 ]
 

--- a/src/common/logger/formatters.ts
+++ b/src/common/logger/formatters.ts
@@ -17,7 +17,7 @@ export const customFormat = format.printf(({ level, message, timestamp, ...metad
     if (Object.keys(metaObj).length > 0) {
       try {
         extraInfo = `\n${JSON.stringify(metaObj, null, 2)}`
-      } catch (e) {
+      } catch {
         extraInfo = `\n[Metadata serialization error]`
       }
     }

--- a/src/main/api/bedrock/services/backgroundAgent/BackgroundAgentScheduler.ts
+++ b/src/main/api/bedrock/services/backgroundAgent/BackgroundAgentScheduler.ts
@@ -874,7 +874,7 @@ export class BackgroundAgentScheduler {
       // 簡易実装として、現在時刻から1分後を設定
       // 実際のcron計算ロジックは複雑なので簡略化
       return Date.now() + 60000 // 1分後
-    } catch (error) {
+    } catch {
       return Date.now() + 3600000 // エラー時は1時間後
     }
   }

--- a/src/main/api/bedrock/services/imageRecognitionService.ts
+++ b/src/main/api/bedrock/services/imageRecognitionService.ts
@@ -107,9 +107,6 @@ export class ImageRecognitionService {
    * 存在確認、形式チェック、サイズ制限などを適用
    */
   private validateImageFile(imagePath: string): void {
-    const fs = require('fs')
-    const path = require('path')
-
     // ファイル存在確認
     if (!fs.existsSync(imagePath)) {
       throw new Error(`Image file not found: ${imagePath}`)
@@ -229,8 +226,6 @@ export class ImageRecognitionService {
     prompt: string,
     modelId: string
   ): Promise<string> {
-    const path = require('path')
-
     // ConverseServiceをインポート
     const converseService = new ConverseService(this.context)
 

--- a/src/main/api/command/commandService.ts
+++ b/src/main/api/command/commandService.ts
@@ -139,7 +139,7 @@ export class CommandService {
   private sanitizeArgs(args: string[]): void {
     for (const arg of args) {
       // Reject potentially dangerous characters
-      if (/[^\w@%+=:,\.\/\-]/.test(arg)) {
+        if (/[^a-zA-Z0-9@%+=:,./-]/.test(arg)) {
         throw new Error(`Invalid characters in argument: ${arg}`)
       }
     }

--- a/src/main/api/sonic/client.ts
+++ b/src/main/api/sonic/client.ts
@@ -823,12 +823,12 @@ export class NovaSonicBidirectionalStreamClient {
                   this.dispatchEvent(sessionId, 'unknown', jsonResponse)
                 }
               }
-            } catch (e) {
-                logger.debug(
-                  `Raw text response for session ${sessionId}(parse error): `,
-                  { textResponse }
-                )
-            }
+              } catch {
+                  logger.debug(
+                    `Raw text response for session ${sessionId}(parse error): `,
+                    { textResponse }
+                  )
+              }
           } catch (e) {
             logger.error(`Error processing response chunk for session ${sessionId}: `, { error: e })
           }

--- a/src/main/handlers/agent-handlers.ts
+++ b/src/main/handlers/agent-handlers.ts
@@ -29,7 +29,7 @@ async function loadSharedAgents(): Promise<{ agents: CustomAgent[]; error: strin
     // Check if the directory exists
     try {
       await fs.promises.access(agentsDir)
-    } catch (error) {
+    } catch {
       // If directory doesn't exist, just return empty array
       return { agents: [], error: null }
     }

--- a/src/main/handlers/todo-handlers.ts
+++ b/src/main/handlers/todo-handlers.ts
@@ -1,4 +1,5 @@
 import { IpcMainInvokeEvent } from 'electron'
+import { homedir } from 'os'
 import { TodoSessionManager, TodoItemUpdate } from '../store/todoSession'
 import { log } from '../../common/logger'
 import { store } from '../../preload/store'
@@ -20,7 +21,7 @@ export const todoHandlers = {
   ) => {
     try {
       const { sessionId, items } = params
-      const projectPath = store.get('projectPath') || require('os').homedir()
+      const projectPath = store.get('projectPath') || homedir()
 
       log.info('Initializing todo list', {
         sessionId,

--- a/src/main/mcp/index.ts
+++ b/src/main/mcp/index.ts
@@ -102,7 +102,7 @@ export const initMcpFromAgentConfig = async (mcpServers: McpServerConfig[] = [])
       if (!hasConfigChanged(mcpServers)) {
         return
       }
-    } catch (error) {
+    } catch {
       // エラーがあっても継続して新しい初期化を開始
     }
   }
@@ -115,7 +115,7 @@ export const initMcpFromAgentConfig = async (mcpServers: McpServerConfig[] = [])
         clients.map(async ({ client }) => {
           try {
             await client.cleanup()
-          } catch (e) {
+          } catch {
             // クリーンアップエラーは無視
           }
         })
@@ -167,7 +167,7 @@ export const initMcpFromAgentConfig = async (mcpServers: McpServerConfig[] = [])
                 serverConfig.env
               )
               return { name: serverConfig.name, client }
-            } catch (e) {
+            } catch {
               return undefined
             }
           })

--- a/src/preload/file.ts
+++ b/src/preload/file.ts
@@ -24,7 +24,7 @@ async function readSharedAgents(): Promise<{ agents: CustomAgent[]; error?: Erro
     // Check if the shared agents directory exists
     try {
       await promisify(fs.access)(sharedAgentsDir)
-    } catch (error) {
+    } catch {
       return { agents: [] }
     }
 
@@ -86,7 +86,7 @@ async function readDirectoryAgents(): Promise<{ agents: CustomAgent[]; error?: E
     // Check if the directory agents directory exists
     try {
       await promisify(fs.access)(agentsDir)
-    } catch (error) {
+    } catch {
       log.debug(`Directory agents directory not found: ${agentsDir}`)
       return { agents: [] }
     }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -131,21 +131,21 @@ if (process.contextIsolated) {
 } else {
   try {
     log.info('Initializing preload APIs (context isolation disabled)')
-    // @ts-ignore (define in dts)
+    // @ts-expect-error (define in dts)
     window.electron = electronAPI
-    // @ts-ignore (define in dts)
+    // @ts-expect-error (define in dts)
     window.api = api
-    // @ts-ignore (define in dts)
+    // @ts-expect-error (define in dts)
     window.store = store
-    // @ts-ignore (define in dts)
+    // @ts-expect-error (define in dts)
     window.file = file
-    // @ts-ignore (define in dts)
+    // @ts-expect-error (define in dts)
     window.chatHistory = chatHistory
-    // @ts-ignore (define in dts)
+    // @ts-expect-error (define in dts)
     window.appWindow = appWindow
-    // @ts-ignore (define in dts)
+    // @ts-expect-error (define in dts)
     window.ipc = ipcClient
-    // @ts-ignore (define in dts)
+    // @ts-expect-error (define in dts)
     window.logger = {
       log: rendererLogger,
       createCategoryLogger: createRendererCategoryLogger

--- a/src/preload/tools/handlers/bedrock/InvokeFlowTool.ts
+++ b/src/preload/tools/handlers/bedrock/InvokeFlowTool.ts
@@ -182,7 +182,7 @@ export class InvokeFlowTool extends BaseTool<InvokeFlowInput, InvokeFlowResult> 
     let parsedInput: any
     try {
       parsedInput = this.parseInput(input.input)
-    } catch (error) {
+    } catch {
       errors.push("Failed to parse input. Ensure it's a valid object or JSON string.")
       return {
         isValid: false,
@@ -320,7 +320,7 @@ export class InvokeFlowTool extends BaseTool<InvokeFlowInput, InvokeFlowResult> 
         nodeOutputName: parsedInput?.nodeOutputName || 'document',
         content: this.sanitizeFlowContent(parsedInput?.content)
       }
-    } catch (error) {
+    } catch {
       sanitizedInput = {
         inputType: typeof input.input,
         inputPreview:

--- a/src/renderer/src/components/JSONViewer/JSONEditor.tsx
+++ b/src/renderer/src/components/JSONViewer/JSONEditor.tsx
@@ -26,7 +26,7 @@ const JSONEditor: React.FC<JSONEditorProps> = ({
       const formatted = JSON.stringify(value || defaultValue, null, 2)
       setJsonText(formatted)
       setLocalError('')
-    } catch (e) {
+    } catch {
       setLocalError('Invalid JSON structure')
     }
   }, [value, defaultValue])
@@ -40,7 +40,7 @@ const JSONEditor: React.FC<JSONEditorProps> = ({
       const parsedValue = JSON.parse(text)
       onChange(parsedValue)
       setLocalError('')
-    } catch (e) {
+    } catch {
       setLocalError('Invalid JSON syntax')
       // エラーがあってもテキスト自体の更新は許可
     }

--- a/src/renderer/src/components/JSONViewer/__tests__/JSONViewer.test.ts
+++ b/src/renderer/src/components/JSONViewer/__tests__/JSONViewer.test.ts
@@ -10,8 +10,10 @@ import { TextEncoder, TextDecoder } from 'util'
 ;(global as any).TextDecoder = TextDecoder
 
 // Import after polyfills to avoid ReferenceError in react-dom/server
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const { renderToString } = require('react-dom/server')
+let renderToString: typeof import('react-dom/server')['renderToString']
+beforeAll(async () => {
+  ;({ renderToString } = await import('react-dom/server'))
+})
 
 describe('JSONViewer sanitization', () => {
   test('renders script tags as harmless text', () => {

--- a/src/renderer/src/components/JSONViewer/index.tsx
+++ b/src/renderer/src/components/JSONViewer/index.tsx
@@ -40,7 +40,7 @@ export const JSONViewer: React.FC<JSONViewerProps> = ({
 
     const elements: React.ReactNode[] = []
     const regex =
-      /("(?:\\u[a-fA-F0-9]{4}|\\[^u]|[^\\"])*"(?:\s*:)?|\b(?:true|false|null)\b|-?\d+(?:\.\d*)?(?:[eE][+\-]?\d+)?)/g
+      /("(?:\\u[a-fA-F0-9]{4}|\\[^u]|[^\\"])*"(?:\s*:)?|\b(?:true|false|null)\b|-?\d+(?:\.\d*)?(?:[eE][+-]?\d+)?)/g
     let lastIndex = 0
 
     sanitized.replace(regex, (match, _p1, offset) => {

--- a/src/renderer/src/components/common/MonacoJSONEditor.tsx
+++ b/src/renderer/src/components/common/MonacoJSONEditor.tsx
@@ -101,7 +101,7 @@ export const MonacoJSONEditor: React.FC<MonacoJSONEditorProps> = ({
       const parsed = JSON.parse(unformatted)
       const formatted = JSON.stringify(parsed, null, 2)
       editorRef.current.setValue(formatted)
-    } catch (error) {
+    } catch {
       // エラーの場合は何もしない（バリデーションが処理する）
     }
   }

--- a/src/renderer/src/pages/BackgroundAgentPage/TaskExecutionHistoryPage.tsx
+++ b/src/renderer/src/pages/BackgroundAgentPage/TaskExecutionHistoryPage.tsx
@@ -243,7 +243,7 @@ const TaskExecutionHistoryPage: React.FC = () => {
           )
         }
         return <JSONViewer data={parsed} title="" maxHeight={maxHeight} showCopyButton={true} />
-      } catch (e) {
+      } catch {
         // JSON parse failed, display as plain text
         return (
           <pre

--- a/src/renderer/src/pages/ChatPage/components/AgentForm/McpServerSection/utils/mcpServerUtils.ts
+++ b/src/renderer/src/pages/ChatPage/components/AgentForm/McpServerSection/utils/mcpServerUtils.ts
@@ -89,7 +89,7 @@ export function parseServerConfigJson(
       success: false,
       error: 'Invalid JSON format. Expected "mcpServers" field with server configurations.'
     }
-  } catch (error) {
+  } catch {
     return { success: false, error: 'Invalid JSON format.' }
   }
 }

--- a/src/renderer/src/pages/ChatPage/components/AgentForm/usePromptGeneration.ts
+++ b/src/renderer/src/pages/ChatPage/components/AgentForm/usePromptGeneration.ts
@@ -80,7 +80,7 @@ function extractCompleteObjects(text: string): GeneratedScenario[] {
           if (isValidScenario(parsed)) {
             scenarios.push(parsed)
           }
-        } catch (e) {
+        } catch {
           // パースに失敗した場合は無視
         }
         currentObject = ''

--- a/src/renderer/src/pages/ChatPage/hooks/useScenarioGenerator.ts
+++ b/src/renderer/src/pages/ChatPage/hooks/useScenarioGenerator.ts
@@ -112,7 +112,7 @@ function extractCompleteObjects(text: string): GeneratedScenario[] {
           if (isValidScenario(parsed)) {
             scenarios.push(parsed)
           }
-        } catch (e) {
+        } catch {
           // パースに失敗した場合は無視
         }
         currentObject = ''

--- a/src/renderer/src/pages/SpeakPage/components/AIIcon.module.css
+++ b/src/renderer/src/pages/SpeakPage/components/AIIcon.module.css
@@ -1,0 +1,146 @@
+@keyframes pulse-glow {
+  0%, 100% {
+    opacity: 0.3;
+    transform: scale(0.95);
+  }
+  50% {
+    opacity: 0.8;
+    transform: scale(1.05);
+  }
+}
+
+@keyframes rotate-slow {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes rotate-reverse {
+  from {
+    transform: rotate(360deg);
+  }
+  to {
+    transform: rotate(0deg);
+  }
+}
+
+@keyframes wave-scale {
+  0%, 100% {
+    transform: scale(1);
+    opacity: 0.8;
+  }
+  50% {
+    transform: scale(1.1);
+    opacity: 0.4;
+  }
+}
+
+@keyframes core-pulse {
+  0%, 100% {
+    opacity: 0.9;
+    transform: scale(1);
+  }
+  50% {
+    opacity: 1;
+    transform: scale(1.15);
+  }
+}
+
+@keyframes recording-pulse {
+  0%, 100% {
+    fill: rgba(239, 68, 68, 0.8);
+    filter: drop-shadow(0 0 20px rgba(239, 68, 68, 0.6));
+  }
+  50% {
+    fill: rgba(239, 68, 68, 1);
+    filter: drop-shadow(0 0 30px rgba(239, 68, 68, 0.9));
+  }
+}
+
+.animateIdle #outer-ring {
+  animation: rotate-slow 20s linear infinite;
+}
+
+.animateIdle #middle-ring {
+  animation: rotate-reverse 15s linear infinite;
+}
+
+.animateIdle #inner-ring {
+  animation: rotate-slow 10s linear infinite;
+}
+
+.animateIdle #core-circle {
+  animation: core-pulse 4s ease-in-out infinite;
+}
+
+.animateProcessing #outer-ring {
+  animation: rotate-slow 3s linear infinite;
+}
+
+.animateProcessing #middle-ring {
+  animation: rotate-reverse 2s linear infinite;
+}
+
+.animateProcessing #inner-ring {
+  animation: rotate-slow 1s linear infinite;
+}
+
+.animateProcessing #wave-1 {
+  animation: wave-scale 2s ease-in-out infinite;
+}
+
+.animateProcessing #wave-2 {
+  animation: wave-scale 2s ease-in-out 0.5s infinite;
+}
+
+.animateProcessing #wave-3 {
+  animation: wave-scale 2s ease-in-out 1s infinite;
+}
+
+.animateProcessing #core-circle {
+  animation: core-pulse 1s ease-in-out infinite;
+}
+
+.animateRecording #outer-ring {
+  animation: rotate-slow 2s linear infinite;
+}
+
+.animateRecording #middle-ring {
+  animation: rotate-reverse 1.5s linear infinite;
+}
+
+.animateRecording #inner-ring {
+  animation: rotate-slow 1s linear infinite;
+}
+
+.animateRecording #core-circle {
+  animation: recording-pulse 1s ease-in-out infinite;
+}
+
+.animateRecording #glow {
+  animation: pulse-glow 1s ease-in-out infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .animateIdle #outer-ring,
+  .animateIdle #middle-ring,
+  .animateIdle #inner-ring,
+  .animateProcessing #outer-ring,
+  .animateProcessing #middle-ring,
+  .animateProcessing #inner-ring,
+  .animateRecording #outer-ring,
+  .animateRecording #middle-ring,
+  .animateRecording #inner-ring {
+    animation: none;
+  }
+
+  .animateIdle #core-circle,
+  .animateProcessing #core-circle,
+  .animateRecording #core-circle {
+    animation: core-pulse 4s ease-in-out infinite;
+  }
+}
+

--- a/src/renderer/src/pages/SpeakPage/components/AIIcon.tsx
+++ b/src/renderer/src/pages/SpeakPage/components/AIIcon.tsx
@@ -1,4 +1,5 @@
 import React, { useMemo } from 'react'
+import styles from './AIIcon.module.css'
 
 export interface AIIconProps {
   isRecording?: boolean
@@ -31,91 +32,13 @@ export const AIIcon: React.FC<AIIconProps> = ({
   }, [size])
 
   const animationClass = isRecording
-    ? 'animate-recording'
+    ? styles.animateRecording
     : isProcessing
-      ? 'animate-processing'
-      : 'animate-idle'
+      ? styles.animateProcessing
+      : styles.animateIdle
 
   return (
     <div className={`relative flex items-center justify-center ${className}`}>
-      {/* Custom CSS for animations */}
-      <style
-        dangerouslySetInnerHTML={{
-          __html: `
-        @keyframes pulse-glow {
-          0%, 100% { opacity: 0.3; transform: scale(0.95); }
-          50% { opacity: 0.8; transform: scale(1.05); }
-        }
-
-        @keyframes rotate-slow {
-          from { transform: rotate(0deg); }
-          to { transform: rotate(360deg); }
-        }
-
-        @keyframes rotate-reverse {
-          from { transform: rotate(360deg); }
-          to { transform: rotate(0deg); }
-        }
-
-        @keyframes wave-scale {
-          0%, 100% { transform: scale(1); opacity: 0.8; }
-          50% { transform: scale(1.1); opacity: 0.4; }
-        }
-
-        @keyframes core-pulse {
-          0%, 100% { opacity: 0.9; transform: scale(1); }
-          50% { opacity: 1; transform: scale(1.15); }
-        }
-
-        @keyframes recording-pulse {
-          0%, 100% {
-            fill: rgba(239, 68, 68, 0.8);
-            filter: drop-shadow(0 0 20px rgba(239, 68, 68, 0.6));
-          }
-          50% {
-            fill: rgba(239, 68, 68, 1);
-            filter: drop-shadow(0 0 30px rgba(239, 68, 68, 0.9));
-          }
-        }
-
-        .animate-idle #outer-ring { animation: rotate-slow 20s linear infinite; }
-        .animate-idle #middle-ring { animation: rotate-reverse 15s linear infinite; }
-        .animate-idle #inner-ring { animation: rotate-slow 10s linear infinite; }
-        .animate-idle #core-circle { animation: core-pulse 4s ease-in-out infinite; }
-
-        .animate-processing #outer-ring { animation: rotate-slow 3s linear infinite; }
-        .animate-processing #middle-ring { animation: rotate-reverse 2s linear infinite; }
-        .animate-processing #inner-ring { animation: rotate-slow 1s linear infinite; }
-        .animate-processing #wave-1 { animation: wave-scale 2s ease-in-out infinite; }
-        .animate-processing #wave-2 { animation: wave-scale 2s ease-in-out 0.5s infinite; }
-        .animate-processing #wave-3 { animation: wave-scale 2s ease-in-out 1s infinite; }
-        .animate-processing #core-circle { animation: core-pulse 1s ease-in-out infinite; }
-
-        .animate-recording #outer-ring { animation: rotate-slow 2s linear infinite; }
-        .animate-recording #middle-ring { animation: rotate-reverse 1.5s linear infinite; }
-        .animate-recording #inner-ring { animation: rotate-slow 1s linear infinite; }
-        .animate-recording #core-circle { animation: recording-pulse 1s ease-in-out infinite; }
-        .animate-recording #glow { animation: pulse-glow 1s ease-in-out infinite; }
-
-        @media (prefers-reduced-motion: reduce) {
-          .animate-idle #outer-ring,
-          .animate-idle #middle-ring,
-          .animate-idle #inner-ring,
-          .animate-processing #outer-ring,
-          .animate-processing #middle-ring,
-          .animate-processing #inner-ring,
-          .animate-recording #outer-ring,
-          .animate-recording #middle-ring,
-          .animate-recording #inner-ring { animation: none; }
-
-          .animate-idle #core-circle,
-          .animate-processing #core-circle,
-          .animate-recording #core-circle { animation: core-pulse 4s ease-in-out infinite; }
-        }
-      `
-        }}
-      />
-
       <svg
         width={dimensions.width}
         height={dimensions.height}

--- a/src/test/src/preload/preload-sandbox.test.ts
+++ b/src/test/src/preload/preload-sandbox.test.ts
@@ -1,11 +1,11 @@
 import { jest } from '@jest/globals'
 
 describe('preload sandbox', () => {
-  test('exposes APIs in isolated context', () => {
+  test('exposes APIs in isolated context', async () => {
     const expose = jest.fn()
     const originalContext = (process as any).contextIsolated
 
-    jest.isolateModules(() => {
+    await jest.isolateModulesAsync(async () => {
       ;(process as any).contextIsolated = true
       jest.doMock('electron', () => ({
         contextBridge: { exposeInMainWorld: expose },
@@ -24,7 +24,7 @@ describe('preload sandbox', () => {
       jest.doMock('../../../preload/ipc-client', () => ({ ipcClient: {} }))
       jest.doMock('../../../preload/tools', () => ({ executeTool: jest.fn() }))
       jest.doMock('../../../preload/tools/registry', () => ({ ToolMetadataCollector: { getToolSpecs: jest.fn() } }))
-      require('../../../preload/index')
+      await import('../../../preload/index')
     })
 
     ;(process as any).contextIsolated = originalContext


### PR DESCRIPTION
## Summary
- extract inline animation CSS from `AIIcon` into `AIIcon.module.css`
- import CSS module and remove `dangerouslySetInnerHTML`
- resolve repo-wide ESLint violations and replace remaining CommonJS `require` calls

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689989159a3883318a755ccf651e42a5