### PR TITLE
chore: harden renderer webPreferences

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -249,6 +249,9 @@ async function createWindow(): Promise<void> {
       preload: join(__dirname, '../preload/index.js'),
       sandbox: true,
       contextIsolation: true,
+      nodeIntegration: false,
+      webviewTag: false,
+      enableRemoteModule: false,
       // Zoom related settings
       zoomFactor: 1.0,
       enableWebSQL: false

--- a/src/test/src/preload/preload-sandbox.test.ts
+++ b/src/test/src/preload/preload-sandbox.test.ts
@@ -2,7 +2,11 @@ import { jest } from '@jest/globals'
 
 describe('preload sandbox', () => {
   test('exposes APIs in isolated context', async () => {
-    const expose = jest.fn()
+    const windowMock: any = {}
+    ;(global as any).window = windowMock
+    const expose = jest.fn((key: string, value: unknown) => {
+      windowMock[key] = value
+    })
     const originalContext = (process as any).contextIsolated
 
     await jest.isolateModulesAsync(async () => {
@@ -44,5 +48,8 @@ describe('preload sandbox', () => {
         'preloadTools'
       ])
     )
+    expect(windowMock.process).toBeUndefined()
+    expect(windowMock.require).toBeUndefined()
+    delete (global as any).window
   })
 })


### PR DESCRIPTION
## Summary
- disable Node access in BrowserWindow webPreferences
- verify preload exposes APIs without leaking Node globals

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6899b88d79ec8331ab93b1c5db659a47