### PR TITLE
chore(security): harden renderer CSP policies

### DIFF
--- a/src/renderer/camera-preview.html
+++ b/src/renderer/camera-preview.html
@@ -7,7 +7,7 @@
     <!-- https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP -->
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' https: data:; connect-src 'self' http://localhost:* ws://localhost:*"
+      content="default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' https: data:; connect-src 'self' http://localhost:* ws://localhost:*; object-src 'none'; base-uri 'self'; frame-ancestors 'none'"
     />
     <link rel="stylesheet" href="camera-preview.css" />
   </head>

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -6,7 +6,7 @@
     <!-- https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP -->
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' https: data:; connect-src 'self' http://localhost:* ws://localhost:*"
+      content="default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' https: data:; connect-src 'self' http://localhost:* ws://localhost:*; object-src 'none'; base-uri 'self'; frame-ancestors 'none'"
     />
   </head>
 


### PR DESCRIPTION
## Summary
- expand renderer CSPs with `object-src 'none'`, `base-uri 'self'`, and `frame-ancestors 'none'`
- keep `connect-src` limited to self and localhost endpoints used by the app

## Testing
- `npm test`
- `node - <<'NODE' ...` (reload index.html via Playwright)
- `node - <<'NODE' ...` (reload camera-preview.html via Playwright)


------
https://chatgpt.com/codex/tasks/task_e_6899b88fd3e483319919e1f1431b9467