### PR TITLE
Restrict URL validation to HTTPS

### DIFF
--- a/src/main/lib/url-utils.ts
+++ b/src/main/lib/url-utils.ts
@@ -16,7 +16,7 @@ const ALLOWED_HOSTS = ['github.com']
 export function isUrlAllowed(targetUrl: string, allowedHosts: string[] = ALLOWED_HOSTS): boolean {
   try {
     const { protocol, hostname } = new URL(targetUrl)
-    if (protocol !== 'http:' && protocol !== 'https:') {
+    if (protocol !== 'https:') {
       return false
     }
     if (allowedHosts.length > 0 && !allowedHosts.includes(hostname)) {

--- a/src/test/src/main/url-utils.test.ts
+++ b/src/test/src/main/url-utils.test.ts
@@ -1,5 +1,5 @@
 import dns from 'dns/promises'
-import { isUrlSafe } from '../../../main/lib/url-utils'
+import { isUrlAllowed, isUrlSafe } from '../../../main/lib/url-utils'
 
 jest.mock('dns/promises')
 
@@ -20,11 +20,25 @@ describe('isUrlSafe', () => {
   })
 
   test('rejects private network URLs', async () => {
-    expect(await isUrlSafe('http://127.0.0.1')).toBe(false)
+    expect(await isUrlSafe('https://127.0.0.1')).toBe(false)
   })
 
-  test('allows whitelisted HTTP URLs', async () => {
+  test('rejects whitelisted HTTP URLs', async () => {
+    expect(await isUrlSafe('http://github.com')).toBe(false)
+  })
+
+  test('allows whitelisted HTTPS URLs', async () => {
     lookupMock.mockResolvedValue([{ address: '1.1.1.1', family: 4 }] as any)
-    expect(await isUrlSafe('http://github.com')).toBe(true)
+    expect(await isUrlSafe('https://github.com')).toBe(true)
+  })
+})
+
+describe('isUrlAllowed', () => {
+  test('rejects http URLs', () => {
+    expect(isUrlAllowed('http://github.com')).toBe(false)
+  })
+
+  test('accepts allowlisted https URLs', () => {
+    expect(isUrlAllowed('https://github.com')).toBe(true)
   })
 })


### PR DESCRIPTION
## Summary
- Require HTTPS in `isUrlAllowed`
- Extend URL safety tests for HTTP rejection and HTTPS allow-list support

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a9af509fc8331bbfee875b93cd5ff