### PR TITLE
feat: use env placeholders for connect-src

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,2 @@
+VITE_API_ENDPOINT=http://localhost:3000
+VITE_WS_ENDPOINT=ws://localhost:3000

--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,12 @@ AWS_REGION=us-east-1
 # Test Configuration
 INTEGRATION_TEST=true
 
+# CSP connect-src endpoints
+# Used to replace placeholders in index.html and camera-preview.html
+# during build. Define the HTTP(S) and WebSocket(S) endpoints allowed.
+VITE_API_ENDPOINT=http://localhost:3000
+VITE_WS_ENDPOINT=ws://localhost:3000
+
 # Example of how to use these environment variables
 # 1. Copy this file to .env
 # 2. Replace the placeholder values with your actual credentials

--- a/.env.production
+++ b/.env.production
@@ -1,0 +1,3 @@
+# Replace with actual production API endpoints
+VITE_API_ENDPOINT=https://api.example.com
+VITE_WS_ENDPOINT=wss://api.example.com

--- a/src/preload/store.ts
+++ b/src/preload/store.ts
@@ -219,10 +219,11 @@ const createElectronStore = async () => {
   return encryptedStore
 }
 
-const electronStore = await createElectronStore()
-log.debug(`store path ${electronStore.path}`)
+let electronStore!: Store<StoreScheme>
 
 const init = async () => {
+  electronStore = await createElectronStore()
+  log.debug(`store path ${electronStore.path}`)
   // Initialize userDataPath if not present
   const userDataPath = electronStore.get('userDataPath')
   if (!userDataPath) {
@@ -383,7 +384,7 @@ const init = async () => {
   }
 }
 
-await init()
+void init()
 
 type Key = keyof StoreScheme
 export const store = {

--- a/src/renderer/camera-preview.html
+++ b/src/renderer/camera-preview.html
@@ -7,7 +7,7 @@
     <!-- https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP -->
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' https: data:; connect-src 'self' http://localhost:* ws://localhost:*; object-src 'none'; base-uri 'self'; frame-ancestors 'none'"
+      content="default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' https: data:; connect-src 'self' %VITE_API_ENDPOINT% %VITE_WS_ENDPOINT%; object-src 'none'; base-uri 'self'; frame-ancestors 'none'"
     />
     <link rel="stylesheet" href="camera-preview.css" />
   </head>

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -6,7 +6,7 @@
     <!-- https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP -->
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' https: data:; connect-src 'self' http://localhost:* ws://localhost:*; object-src 'none'; base-uri 'self'; frame-ancestors 'none'"
+      content="default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' https: data:; connect-src 'self' %VITE_API_ENDPOINT% %VITE_WS_ENDPOINT%; object-src 'none'; base-uri 'self'; frame-ancestors 'none'"
     />
   </head>
 


### PR DESCRIPTION
## Summary
- replace hardcoded localhost connect-src values with `%VITE_API_ENDPOINT%` and `%VITE_WS_ENDPOINT%` in renderer HTML
- provide example and environment-specific `.env` files defining CSP endpoints
- fix build by removing top-level await in preload store initialization

## Testing
- `npm test`
- `npm run lint`
- `node -e "const fs=require('fs');const dotenv=require('dotenv');dotenv.config({path:'.env.development'});let html=fs.readFileSync('src/renderer/index.html','utf8');for(const [k,v] of Object.entries(process.env)){html=html.replace(new RegExp('%'+k+'%','g'), v);}console.log(html.match(/connect-src[^;]*;/)[0]);"`
- `node -e "const fs=require('fs');const dotenv=require('dotenv');dotenv.config({path:'.env.production'});let html=fs.readFileSync('src/renderer/index.html','utf8');for(const [k,v] of Object.entries(process.env)){html=html.replace(new RegExp('%'+k+'%','g'), v);}console.log(html.match(/connect-src[^;]*;/)[0]);"`
- `node -e "const fs=require('fs');const dotenv=require('dotenv');dotenv.config({path:'.env.development'});let html=fs.readFileSync('src/renderer/camera-preview.html','utf8');for(const [k,v] of Object.entries(process.env)){html=html.replace(new RegExp('%'+k+'%','g'), v);}console.log(html.match(/connect-src[^;]*;/)[0]);"`
- `node -e "const fs=require('fs');const dotenv=require('dotenv');dotenv.config({path:'.env.production'});let html=fs.readFileSync('src/renderer/camera-preview.html','utf8');for(const [k,v] of Object.entries(process.env)){html=html.replace(new RegExp('%'+k+'%','g'), v);}console.log(html.match(/connect-src[^;]*;/)[0]);"`
- `npm run build -- --mode development`


------
https://chatgpt.com/codex/tasks/task_e_689c2b5a11b0833189cb94e78ea0f5b8