### PR TITLE
feat: make scheduler timezone configurable

### DIFF
--- a/src/main/api/bedrock/services/backgroundAgent/BackgroundAgentScheduler.ts
+++ b/src/main/api/bedrock/services/backgroundAgent/BackgroundAgentScheduler.ts
@@ -15,15 +15,17 @@ export class BackgroundAgentScheduler {
   private cronJobs: Map<string, cron.ScheduledTask> = new Map()
   private backgroundAgentService: BackgroundAgentService
   private context: ServiceContext
-  private executionHistoryStore: Store<{
-    executionHistory: { [key: string]: TaskExecutionResult[] }
-  }>
+  private executionHistoryStore: any
   private notificationService: MainNotificationService
-
-  constructor(context: ServiceContext) {
+  private timezone: string
+  constructor(context: ServiceContext, timezone?: string) {
     this.context = context
     this.backgroundAgentService = new BackgroundAgentService(context)
     this.notificationService = new MainNotificationService(context)
+    this.timezone =
+      timezone ||
+      (this.context.store.get('timezone') as string | undefined) ||
+      Intl.DateTimeFormat().resolvedOptions().timeZone
 
     // 実行履歴用のストアを初期化
     this.executionHistoryStore = new Store({
@@ -31,7 +33,7 @@ export class BackgroundAgentScheduler {
       defaults: {
         executionHistory: {} as { [key: string]: TaskExecutionResult[] }
       }
-    })
+    }) as any
 
     // BackgroundAgentServiceにコールバックを設定してリアルタイム更新を有効化
     this.backgroundAgentService.setExecutionHistoryUpdateCallback(
@@ -289,7 +291,7 @@ export class BackgroundAgentScheduler {
           await this.executeTask(taskId)
         },
         {
-          timezone: 'Asia/Tokyo' // タイムゾーンを設定
+          timezone: this.timezone // タイムゾーンを設定
         }
       )
 

--- a/src/main/api/bedrock/services/backgroundAgent/BackgroundAgentService.ts
+++ b/src/main/api/bedrock/services/backgroundAgent/BackgroundAgentService.ts
@@ -901,7 +901,10 @@ export class BackgroundAgentService {
   async getTaskSystemPrompt(taskId: string): Promise<string> {
     try {
       // BackgroundAgentSchedulerから対象タスクを取得
-      const scheduler = new BackgroundAgentScheduler(this.context)
+      const scheduler = new BackgroundAgentScheduler(
+        this.context,
+        this.context.store.get('timezone') as string | undefined
+      )
       const task = scheduler.getTask(taskId)
 
       if (!task) {

--- a/src/main/api/bedrock/services/backgroundAgent/__tests__/BackgroundAgentScheduler.test.ts
+++ b/src/main/api/bedrock/services/backgroundAgent/__tests__/BackgroundAgentScheduler.test.ts
@@ -1,0 +1,66 @@
+jest.mock('../BackgroundAgentService', () => ({
+  BackgroundAgentService: jest.fn().mockImplementation(() => ({
+    setExecutionHistoryUpdateCallback: jest.fn()
+  }))
+}))
+
+jest.mock('../../NotificationService', () => ({
+  MainNotificationService: jest.fn().mockImplementation(() => ({}))
+}))
+
+jest.mock('node-cron', () => ({
+  schedule: jest.fn().mockReturnValue({ stop: jest.fn(), destroy: jest.fn() }),
+  validate: jest.fn().mockReturnValue(true)
+}))
+
+jest.mock('electron-store', () => {
+  return jest.fn().mockImplementation(() => ({
+    get: jest.fn(),
+    set: jest.fn()
+  }))
+})
+
+import * as cron from 'node-cron'
+import { BackgroundAgentScheduler } from '../BackgroundAgentScheduler'
+import { ScheduledTask } from '../types'
+
+describe('BackgroundAgentScheduler timezone', () => {
+  const scheduleMock = cron.schedule as jest.Mock
+
+  const createScheduler = (tz: string) => {
+    const mockStore = {
+      get: (key: string) => {
+        if (key === 'timezone') return tz
+        if (key === 'backgroundAgentScheduledTasks') return []
+        return undefined
+      },
+      set: jest.fn()
+    }
+    return new BackgroundAgentScheduler({ store: mockStore as any }, tz)
+  }
+
+  beforeEach(() => {
+    scheduleMock.mockClear()
+  })
+
+  it.each(['Asia/Tokyo', 'America/New_York'])('uses provided timezone %s', (tz) => {
+    const scheduler = createScheduler(tz)
+    const task: ScheduledTask = {
+      id: '1',
+      name: 'test',
+      cronExpression: '* * * * *',
+      agentId: 'a',
+      modelId: 'm',
+      wakeWord: 'hello',
+      enabled: true,
+      createdAt: Date.now(),
+      runCount: 0
+    }
+    ;(scheduler as any).startCronJob(task)
+    expect(scheduleMock).toHaveBeenCalledWith(
+      task.cronExpression,
+      expect.any(Function),
+      expect.objectContaining({ timezone: tz })
+    )
+  })
+})

--- a/src/main/handlers/background-agent-handlers.ts
+++ b/src/main/handlers/background-agent-handlers.ts
@@ -36,7 +36,10 @@ function getBackgroundAgentScheduler(): BackgroundAgentScheduler {
       const context: ServiceContext = {
         store: store
       }
-      backgroundAgentScheduler = new BackgroundAgentScheduler(context)
+      backgroundAgentScheduler = new BackgroundAgentScheduler(
+        context,
+        store.get('timezone')
+      )
       logger.info('BackgroundAgentScheduler instance created')
     } catch (error: any) {
       logger.error('Failed to create BackgroundAgentScheduler instance', {

--- a/src/preload/store.ts
+++ b/src/preload/store.ts
@@ -107,6 +107,9 @@ type StoreScheme = {
   /** アプリケーションの表示言語設定（日本語または英語） */
   language: 'ja' | 'en'
 
+  /** スケジューラで使用するタイムゾーン */
+  timezone?: string
+
   /** エージェントチャットの設定（無視するファイル一覧、コンテキスト長など） */
   agentChatConfig: AgentChatConfig
 
@@ -249,6 +252,11 @@ const init = async () => {
   const language = electronStore.get('language')
   if (language === undefined) {
     electronStore.set('language', 'en')
+  }
+
+  const timezone = electronStore.get('timezone')
+  if (!timezone) {
+    electronStore.set('timezone', Intl.DateTimeFormat().resolvedOptions().timeZone)
   }
 
   // Initialize AWS settings if not present


### PR DESCRIPTION
## Summary
- allow BackgroundAgentScheduler to use timezone from settings or system default
- pass timezone through scheduler constructors
- persist timezone in store and add tests for multiple timezones

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c5effd0608331862ee1fac68df794