### PR TITLE
Validate persisted background tasks before restoration

### DIFF
--- a/src/main/api/bedrock/services/backgroundAgent/__tests__/BackgroundAgentScheduler.test.ts
+++ b/src/main/api/bedrock/services/backgroundAgent/__tests__/BackgroundAgentScheduler.test.ts
@@ -1,3 +1,17 @@
+const infoMock = jest.fn()
+const warnMock = jest.fn()
+const errorMock = jest.fn()
+const debugMock = jest.fn()
+
+jest.mock('../../../../../../common/logger', () => ({
+  createCategoryLogger: jest.fn(() => ({
+    info: infoMock,
+    warn: warnMock,
+    error: errorMock,
+    debug: debugMock
+  }))
+}))
+
 jest.mock('../BackgroundAgentService', () => ({
   BackgroundAgentService: jest.fn().mockImplementation(() => ({
     setExecutionHistoryUpdateCallback: jest.fn()
@@ -62,5 +76,63 @@ describe('BackgroundAgentScheduler timezone', () => {
       expect.any(Function),
       expect.objectContaining({ timezone: tz })
     )
+  })
+})
+
+describe('restorePersistedTasks validation', () => {
+  const scheduleMock = cron.schedule as jest.Mock
+
+  const createScheduler = (persisted: any[]) => {
+    const mockStore = {
+      get: (key: string) => {
+        if (key === 'timezone') return 'UTC'
+        if (key === 'backgroundAgentScheduledTasks') return persisted
+        return undefined
+      },
+      set: jest.fn()
+    }
+    return new BackgroundAgentScheduler({ store: mockStore as any }, 'UTC')
+  }
+
+  beforeEach(() => {
+    scheduleMock.mockClear()
+    warnMock.mockClear()
+  })
+
+  it('restores valid persisted tasks', () => {
+    const validTask = {
+      id: '1',
+      name: 'test',
+      cronExpression: '* * * * *',
+      agentId: 'a',
+      modelId: 'm',
+      wakeWord: 'hello',
+      enabled: true,
+      createdAt: Date.now(),
+      runCount: 0
+    }
+    const scheduler = createScheduler([validTask])
+    expect((scheduler as any).scheduledTasks.size).toBe(1)
+    expect(scheduleMock).toHaveBeenCalledTimes(1)
+    expect(warnMock).not.toHaveBeenCalled()
+  })
+
+  it('skips invalid persisted tasks', () => {
+    const validTask = {
+      id: '1',
+      name: 'test',
+      cronExpression: '* * * * *',
+      agentId: 'a',
+      modelId: 'm',
+      wakeWord: 'hello',
+      enabled: true,
+      createdAt: Date.now(),
+      runCount: 0
+    }
+    const invalidTask = { id: '2' }
+    const scheduler = createScheduler([validTask, invalidTask])
+    expect((scheduler as any).scheduledTasks.size).toBe(1)
+    expect(scheduleMock).toHaveBeenCalledTimes(1)
+    expect(warnMock).toHaveBeenCalledTimes(1)
   })
 })


### PR DESCRIPTION
## Summary
- validate persisted background agent tasks with a zod schema before restoration
- log and skip invalid persisted tasks
- add unit tests for valid and invalid persisted task data

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c627499cc8331b484511f55feae17