### PR TITLE
Ensure timed-out commands terminate cleanly

### DIFF
--- a/src/main/api/command/commandService.ts
+++ b/src/main/api/command/commandService.ts
@@ -297,6 +297,9 @@ Working Directory: ${input.cwd}`
       let isCompleted = false
 
       const cleanup = () => {
+        childProcess.stdout.removeAllListeners()
+        childProcess.stderr.removeAllListeners()
+        childProcess.removeAllListeners()
         this.runningProcesses.delete(pid)
         this.processStates.delete(pid)
       }
@@ -444,7 +447,7 @@ Working Directory: ${input.cwd}`
 
       const TIMEOUT = 60000 * 5 // 5分
       // タイムアウト処理
-      setTimeout(() => {
+      setTimeout(async () => {
         if (!isCompleted) {
           const state = this.processStates.get(pid)
           if (!state) return
@@ -459,6 +462,9 @@ Working Directory: ${input.cwd}`
             ) {
               completeWithSuccess()
             } else {
+              await this.stopProcess(pid).catch((err) =>
+                log.error(`Failed to stop process ${pid}:`, err)
+              )
               completeWithError('Command timed out')
             }
           }
@@ -598,17 +604,42 @@ Working Directory: ${input.cwd}`
   }
 
   async stopProcess(pid: number): Promise<void> {
-    const processInfo = this.runningProcesses.get(pid)
-    if (processInfo) {
-      try {
-        process.kill(-pid) // プロセスグループ全体を終了
+    const state = this.processStates.get(pid)
+    const childProcess = state?.process
+
+    if (!this.runningProcesses.has(pid)) {
+      return
+    }
+
+    return new Promise((resolve, reject) => {
+      const cleanup = () => {
+        childProcess?.stdout?.removeAllListeners()
+        childProcess?.stderr?.removeAllListeners()
+        childProcess?.removeAllListeners()
         this.runningProcesses.delete(pid)
         this.processStates.delete(pid)
-      } catch (error) {
-        const errorMessage = error instanceof Error ? error.message : 'Unknown error'
-        throw new Error(`Failed to stop process ${pid}: ${errorMessage}`)
+        resolve()
       }
-    }
+
+      if (childProcess) {
+        childProcess.stdout?.removeAllListeners()
+        childProcess.stderr?.removeAllListeners()
+        childProcess.removeAllListeners('error')
+        childProcess.removeAllListeners('exit')
+        childProcess.once('exit', cleanup)
+      } else {
+        cleanup()
+      }
+
+      try {
+        // プロセスグループ全体を終了
+        process.kill(-pid)
+      } catch (error) {
+        childProcess?.removeAllListeners('exit')
+        const errorMessage = error instanceof Error ? error.message : 'Unknown error'
+        reject(new Error(`Failed to stop process ${pid}: ${errorMessage}`))
+      }
+    })
   }
 
   getRunningProcesses(): DetachedProcessInfo[] {

--- a/src/test/src/main/command-service.timeout.test.ts
+++ b/src/test/src/main/command-service.timeout.test.ts
@@ -1,0 +1,43 @@
+import { CommandService } from '../../../main/api/command/commandService'
+
+describe('CommandService timeout handling', () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  test('kills long running process when timeout elapses', async () => {
+    const service = new CommandService({
+      allowedCommands: [{ pattern: 'sleep 1000', description: 'test' }],
+      shell: '/bin/bash'
+    })
+
+    const promise = service.executeCommand({
+      command: 'sleep 1000',
+      cwd: process.cwd()
+    })
+
+    const running = service.getRunningProcesses()
+    expect(running.length).toBe(1)
+    const pid = running[0].pid
+
+    // process should exist
+    expect(() => process.kill(pid, 0)).not.toThrow()
+
+    // Fast-forward to trigger the timeout
+    jest.advanceTimersByTime(5 * 60 * 1000)
+
+    await expect(promise).rejects.toThrow('Command timed out')
+
+    // allow event loop to process kill
+    await Promise.resolve()
+
+    // process should be terminated and removed
+    expect(() => process.kill(pid, 0)).toThrow()
+    expect(service.getRunningProcesses().length).toBe(0)
+  })
+})
+


### PR DESCRIPTION
## Summary
- clear process listeners and tracking after termination
- stop timed-out commands via stopProcess
- test that long-running commands are killed on timeout

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d4c09d2108331b7bfabfc69132ffa